### PR TITLE
Support for Spotify playlists by loading track through Youtube/Soundcloud

### DIFF
--- a/FredBoat/credentials.yaml.example
+++ b/FredBoat/credentials.yaml.example
@@ -36,3 +36,9 @@ mashapeKey:
 # acquired from here: https://api.imgur.com/oauth2/addclient
 # choose an option that does not require an Authorization callback URL
 imgurClientId:
+
+
+# Used to retrieve Spotify playlists
+# Get them from here: https://developer.spotify.com/my-applications
+spotifyId:
+spotifySecret:

--- a/FredBoat/src/main/java/fredboat/Config.java
+++ b/FredBoat/src/main/java/fredboat/Config.java
@@ -71,6 +71,8 @@ public class Config {
     private String carbonKey;
     private String cbUser;
     private String cbKey;
+    private String spotifyId;
+    private String spotifySecret;
     private String prefix = DEFAULT_PREFIX;
     private boolean restServerEnabled = true;
     private List<String> adminIds = new ArrayList<>();
@@ -136,7 +138,8 @@ public class Config {
             if (token != null) {
                 botToken = token.getOrDefault(distribution.getId(), "");
             } else botToken = "";
-
+            spotifyId = (String) creds.getOrDefault("spotifyId", "");
+            spotifySecret = (String) creds.getOrDefault("spotifySecret", "");
 
             if (creds.containsKey("oauthSecret")) {
                 Map<String, Object> oas = (Map) creds.get("oauthSecret");
@@ -310,6 +313,14 @@ public class Config {
 
     public String getCbKey() {
         return cbKey;
+    }
+
+    public String getSpotifyId() {
+        return spotifyId;
+    }
+
+    public String getSpotifySecret() {
+        return spotifySecret;
     }
 
     public String getPrefix() {

--- a/FredBoat/src/main/java/fredboat/audio/AbstractPlayer.java
+++ b/FredBoat/src/main/java/fredboat/audio/AbstractPlayer.java
@@ -103,7 +103,9 @@ public abstract class AbstractPlayer extends AudioEventAdapter implements AudioS
         mng.registerSourceManager(new TwitchStreamAudioSourceManager());
         mng.registerSourceManager(new VimeoAudioSourceManager());
         mng.registerSourceManager(new BeamAudioSourceManager());
-        mng.registerSourceManager(new SpotifyPlaylistSourceManager());
+        if (Config.CONFIG.getDistribution() == DistributionEnum.PATRON || Config.CONFIG.getDistribution() == DistributionEnum.DEVELOPMENT) {
+            mng.registerSourceManager(new SpotifyPlaylistSourceManager());
+        }
         //add new source managers above the HttpAudio one, because it will either eat your request or throw an exception
         //so you will never reach a source manager below it
         mng.registerSourceManager(new HttpAudioSourceManager());

--- a/FredBoat/src/main/java/fredboat/audio/AbstractPlayer.java
+++ b/FredBoat/src/main/java/fredboat/audio/AbstractPlayer.java
@@ -48,6 +48,7 @@ import fredboat.audio.queue.ITrackProvider;
 import fredboat.audio.queue.SplitAudioTrackContext;
 import fredboat.audio.queue.TrackEndMarkerHandler;
 import fredboat.audio.source.PlaylistImportSourceManager;
+import fredboat.audio.source.SpotifyPlaylistSourceManager;
 import fredboat.util.DistributionEnum;
 import net.dv8tion.jda.core.audio.AudioSendHandler;
 import org.slf4j.LoggerFactory;
@@ -102,6 +103,9 @@ public abstract class AbstractPlayer extends AudioEventAdapter implements AudioS
         mng.registerSourceManager(new TwitchStreamAudioSourceManager());
         mng.registerSourceManager(new VimeoAudioSourceManager());
         mng.registerSourceManager(new BeamAudioSourceManager());
+        mng.registerSourceManager(new SpotifyPlaylistSourceManager());
+        //add new source managers above the HttpAudio one, because it will either eat your request or throw an exception
+        //so you will never reach a source manager below it
         mng.registerSourceManager(new HttpAudioSourceManager());
         
         return mng;

--- a/FredBoat/src/main/java/fredboat/audio/queue/AudioLoader.java
+++ b/FredBoat/src/main/java/fredboat/audio/queue/AudioLoader.java
@@ -74,7 +74,7 @@ public class AudioLoader implements AudioLoadResultHandler {
 
     public void loadAsync(IdentifierContext ic) {
         identifierQueue.add(ic);
-        FredBoat.executor.submit(() -> announceIfPlaylist(ic));
+        FredBoat.executor.submit(() -> announceIfLongPlaylist(ic));
         if (!isLoading) {
             loadNextAsync();
         }
@@ -107,14 +107,14 @@ public class AudioLoader implements AudioLoadResultHandler {
     /**
      * If the requested item is a playlist that we know of, announce to the user that it might take a while to gather it.
      */
-    private void announceIfPlaylist(IdentifierContext ic) {
+    private void announceIfLongPlaylist(IdentifierContext ic) {
         PlaylistInfo playlistInfo = getPlaylistData(ic.identifier);
-        if (playlistInfo != null) {
-            //inform user we are possibly about to do nasty time consuming work
-            if (playlistInfo.getTotalTracks() > 10) //arbitrary chosen number
-                TextUtils.replyWithName(gplayer.getActiveTextChannel(), ic.getMember(),
-                        MessageFormat.format(I18n.get(ic.getMember().getGuild()).getString("loadAnnouncePlaylist"), playlistInfo.getName(), playlistInfo.getTotalTracks()));
-
+        //inform user we are possibly about to do nasty time consuming work
+        if (playlistInfo != null && playlistInfo.getTotalTracks() > 50) {
+            String out = MessageFormat.format(I18n.get(ic.getMember().getGuild()).getString("loadAnnouncePlaylist"),
+                    playlistInfo.getName(),
+                    playlistInfo.getTotalTracks());
+            TextUtils.replyWithName(gplayer.getActiveTextChannel(), ic.getMember(), out);
         }
     }
 

--- a/FredBoat/src/main/java/fredboat/audio/queue/PlaylistInfo.java
+++ b/FredBoat/src/main/java/fredboat/audio/queue/PlaylistInfo.java
@@ -1,0 +1,47 @@
+package fredboat.audio.queue;
+
+/**
+ * Created by napster on 16.03.17.
+ * <p>
+ * Helps us transfer some information about playlists.
+ */
+public class PlaylistInfo {
+
+    public enum Source {PASTESERVICE, SPOTIFY}
+
+    private int totalTracks;
+
+    private String name;
+
+    private Source source;
+
+    public PlaylistInfo(int totalTracks, String name, Source source) {
+        this.totalTracks = totalTracks;
+        this.name = name;
+        this.source = source;
+    }
+
+    public int getTotalTracks() {
+        return totalTracks;
+    }
+
+    public void setTotalTracks(int totalTracks) {
+        this.totalTracks = totalTracks;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Source getSource() {
+        return source;
+    }
+
+    public void setSource(Source source) {
+        this.source = source;
+    }
+}

--- a/FredBoat/src/main/java/fredboat/audio/source/PlaylistImportSourceManager.java
+++ b/FredBoat/src/main/java/fredboat/audio/source/PlaylistImportSourceManager.java
@@ -25,6 +25,18 @@
 
 package fredboat.audio.source;
 
+import com.mashape.unirest.http.Unirest;
+import com.mashape.unirest.http.exceptions.UnirestException;
+import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler;
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
+import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
+import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
+import com.sedmelluq.discord.lavaplayer.track.*;
+import fredboat.audio.AbstractPlayer;
+import fredboat.audio.queue.PlaylistInfo;
+import org.slf4j.LoggerFactory;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -34,25 +46,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 
-import org.slf4j.LoggerFactory;
-
-import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.exceptions.UnirestException;
-import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler;
-import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
-import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
-import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
-import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
-import com.sedmelluq.discord.lavaplayer.track.AudioItem;
-import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist;
-import com.sedmelluq.discord.lavaplayer.track.AudioReference;
-import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
-import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
-import com.sedmelluq.discord.lavaplayer.track.BasicAudioPlaylist;
-
-import fredboat.audio.AbstractPlayer;
-
-public class PlaylistImportSourceManager implements AudioSourceManager {
+public class PlaylistImportSourceManager implements AudioSourceManager, PlaylistImporter {
 
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(PlaylistImportSourceManager.class);
 
@@ -66,58 +60,21 @@ public class PlaylistImportSourceManager implements AudioSourceManager {
 
     @Override
     public AudioItem loadItem(DefaultAudioPlayerManager manager, AudioReference ar) {
-        String pasteId;
-        String response;
-        Matcher m;
-        Matcher serviceNameMatcher = PasteServiceConstants.SERVICE_NAME_PATTERN.matcher(ar.identifier);
 
-        if (!serviceNameMatcher.find()) {
+        String[] parsed = parse(ar.identifier);
+        if (parsed == null) return null;
+        String serviceName = parsed[0];
+        String pasteId = parsed[1];
+
+
+        if (pasteId == null || "".equals(pasteId) || !PasteServiceConstants.PASTE_SERVICE_URLS.containsKey(serviceName)) {
             return null;
         }
-
-        String serviceName = serviceNameMatcher.group(1).trim().toLowerCase();
-
-        switch (serviceName) {
-
-        case "hastebin":
-            m = PasteServiceConstants.HASTEBIN_PATTERN.matcher(ar.identifier);
-            pasteId = m.find() ? m.group(1) : null;
-            break;
-
-        case "pastebin":
-            m = PasteServiceConstants.PASTEBIN_PATTERN.matcher(ar.identifier);
-            pasteId = m.find() ? m.group(1) : null;
-            break;
-
-        default:
-            return null;
-        }
-
-        if (pasteId == null || !PasteServiceConstants.PASTE_SERVICE_URLS.containsKey(serviceName)) {
-            return null;
-        }
-
-        try {
-            response = Unirest.get(PasteServiceConstants.PASTE_SERVICE_URLS.get(serviceName) + pasteId).asString()
-                    .getBody();
-        } catch (UnirestException ex) {
-            throw new FriendlyException(
-                    "Couldn't load playlist. Either " + serviceName + " is down or the playlist does not exist.",
-                    FriendlyException.Severity.FAULT, ex);
-        }
-
-        String[] unfiltered = response.split("\\s");
-        ArrayList<String> filtered = new ArrayList<>();
-
-        for (String str : unfiltered) {
-            if (!str.equals("")) {
-                filtered.add(str);
-            }
-        }
+        List<String> trackIds = loadAndParseTrackIds(serviceName, pasteId);
 
         PasteServiceAudioResultHandler handler = new PasteServiceAudioResultHandler();
         Future<Void> lastFuture = null;
-        for (String id : filtered) {
+        for (String id : trackIds) {
             lastFuture = PRIVATE_MANAGER.loadItemOrdered(handler, id, handler);
         }
 
@@ -151,6 +108,79 @@ public class PlaylistImportSourceManager implements AudioSourceManager {
 
     @Override
     public void shutdown() {
+    }
+
+    /**
+     * @return null or a string with the hasteId
+     */
+    private String[] parse(String identifier) {
+        String pasteId;
+        Matcher m;
+        Matcher serviceNameMatcher = PasteServiceConstants.SERVICE_NAME_PATTERN.matcher(identifier);
+
+        if (!serviceNameMatcher.find()) {
+            return null;
+        }
+
+        String serviceName = serviceNameMatcher.group(1).trim().toLowerCase();
+
+        switch (serviceName) {
+
+            case "hastebin":
+                m = PasteServiceConstants.HASTEBIN_PATTERN.matcher(identifier);
+                pasteId = m.find() ? m.group(1) : null;
+                break;
+
+            case "pastebin":
+                m = PasteServiceConstants.PASTEBIN_PATTERN.matcher(identifier);
+                pasteId = m.find() ? m.group(1) : null;
+                break;
+
+            default:
+                return null;
+        }
+
+        String[] result = new String[2];
+        result[0] = serviceName;
+        result[1] = pasteId;
+        return result;
+    }
+
+    private List<String> loadAndParseTrackIds(String serviceName, String pasteId) {
+        String response;
+        try {
+            response = Unirest.get(PasteServiceConstants.PASTE_SERVICE_URLS.get(serviceName) + pasteId).asString()
+                    .getBody();
+        } catch (UnirestException ex) {
+            throw new FriendlyException(
+                    "Couldn't load playlist. Either " + serviceName + " is down or the playlist does not exist.",
+                    FriendlyException.Severity.FAULT, ex);
+        }
+
+        String[] unfiltered = response.split("\\s");
+        ArrayList<String> filtered = new ArrayList<>();
+        for (String str : unfiltered) {
+            if (!str.equals("")) {
+                filtered.add(str);
+            }
+        }
+        return filtered;
+    }
+
+
+    @Override
+    public PlaylistInfo isPlaylistAndIfYesGimmeSomeData(String identifier) {
+
+        String[] pasteData = parse(identifier);
+        if (pasteData == null) return null;
+
+        String serviceName = pasteData[0];
+        String pasteId = pasteData[1];
+        if (serviceName == null || "".equals(serviceName) || pasteId == null || "".equals(pasteId)) return null;
+
+        List<String> trackIds = loadAndParseTrackIds(serviceName, pasteId);
+
+        return new PlaylistInfo(trackIds.size(), pasteId, PlaylistInfo.Source.PASTESERVICE);
     }
 
     private class PasteServiceAudioResultHandler implements AudioLoadResultHandler {

--- a/FredBoat/src/main/java/fredboat/audio/source/PlaylistImportSourceManager.java
+++ b/FredBoat/src/main/java/fredboat/audio/source/PlaylistImportSourceManager.java
@@ -111,7 +111,7 @@ public class PlaylistImportSourceManager implements AudioSourceManager, Playlist
     }
 
     /**
-     * @return null or a string with the hasteId
+     * @return null or a string array containing the service name at [0] and the paste id at [1] of the requested playlist
      */
     private String[] parse(String identifier) {
         String pasteId;
@@ -169,7 +169,7 @@ public class PlaylistImportSourceManager implements AudioSourceManager, Playlist
 
 
     @Override
-    public PlaylistInfo isPlaylistAndIfYesGimmeSomeData(String identifier) {
+    public PlaylistInfo getPlaylistDataBlocking(String identifier) {
 
         String[] pasteData = parse(identifier);
         if (pasteData == null) return null;

--- a/FredBoat/src/main/java/fredboat/audio/source/PlaylistImporter.java
+++ b/FredBoat/src/main/java/fredboat/audio/source/PlaylistImporter.java
@@ -11,5 +11,5 @@ public interface PlaylistImporter {
      * @param identifier the same string by which the importer may be asked to load the whole playlist
      * @return information about the playlist or null if it's not a playlist recognized by this importer
      */
-    PlaylistInfo isPlaylistAndIfYesGimmeSomeData(String identifier);
+    PlaylistInfo getPlaylistDataBlocking(String identifier);
 }

--- a/FredBoat/src/main/java/fredboat/audio/source/PlaylistImporter.java
+++ b/FredBoat/src/main/java/fredboat/audio/source/PlaylistImporter.java
@@ -1,0 +1,15 @@
+package fredboat.audio.source;
+
+import fredboat.audio.queue.PlaylistInfo;
+
+public interface PlaylistImporter {
+
+    /**
+     * this should try to acquire as much data as possible about a playlist in a lightweight way
+     * if necessary, a few http requests are ok
+     *
+     * @param identifier the same string by which the importer may be asked to load the whole playlist
+     * @return information about the playlist or null if it's not a playlist recognized by this importer
+     */
+    PlaylistInfo isPlaylistAndIfYesGimmeSomeData(String identifier);
+}

--- a/FredBoat/src/main/java/fredboat/audio/source/SpotifyPlaylistSourceManager.java
+++ b/FredBoat/src/main/java/fredboat/audio/source/SpotifyPlaylistSourceManager.java
@@ -50,7 +50,7 @@ public class SpotifyPlaylistSourceManager implements AudioSourceManager, Playlis
 
         PlaylistInfo plData;
         try {
-            plData = saw.getPlaylistData(spotifyUser, spotifyListId);
+            plData = saw.getPlaylistDataBlocking(spotifyUser, spotifyListId);
         } catch (Exception e) {
             log.warn("Could not retrieve playlist " + spotifyListId + " of user " + spotifyUser, e);
             throw new FriendlyException("Couldn't load playlist. Either Spotify is down or the playlist does not exist.", FriendlyException.Severity.COMMON, e);
@@ -64,7 +64,7 @@ public class SpotifyPlaylistSourceManager implements AudioSourceManager, Playlis
         final List<String> trackListSearchTerms;
 
         try {
-            trackListSearchTerms = saw.getPlaylistTracksSearchTerms(spotifyUser, spotifyListId);
+            trackListSearchTerms = saw.getPlaylistTracksSearchTermsBlocking(spotifyUser, spotifyListId);
         } catch (Exception e) {
             log.warn("Could not retrieve tracks for playlist " + spotifyListId + " of user " + spotifyUser, e);
             throw new FriendlyException("Couldn't load playlist. Either Spotify is down or the playlist does not exist.", FriendlyException.Severity.COMMON, e);
@@ -162,7 +162,7 @@ public class SpotifyPlaylistSourceManager implements AudioSourceManager, Playlis
      * @return null or a string array containing spotifyUser at [0] and playlistId at [1] of the requested playlist
      */
     private String[] parse(String identifier) {
-        String[] result = new String[0];
+        String[] result = new String[2];
         final Matcher m = PLAYLIST_PATTERN.matcher(identifier);
 
         if (!m.find()) {
@@ -177,7 +177,7 @@ public class SpotifyPlaylistSourceManager implements AudioSourceManager, Playlis
     }
 
     @Override
-    public PlaylistInfo isPlaylistAndIfYesGimmeSomeData(String identifier) {
+    public PlaylistInfo getPlaylistDataBlocking(String identifier) {
 
         String[] data = parse(identifier);
         if (data == null) return null;
@@ -185,7 +185,7 @@ public class SpotifyPlaylistSourceManager implements AudioSourceManager, Playlis
         final String spotifyListId = data[1];
 
         try {
-            return SpotifyAPIWrapper.getApi().getPlaylistData(spotifyUser, spotifyListId);
+            return SpotifyAPIWrapper.getApi().getPlaylistDataBlocking(spotifyUser, spotifyListId);
         } catch (Exception e) {
             log.warn("Could not retrieve playlist " + spotifyListId + " of user " + spotifyUser, e);
             throw new FriendlyException("Couldn't load playlist. Either Spotify is down or the playlist does not exist.", FriendlyException.Severity.COMMON, e);

--- a/FredBoat/src/main/java/fredboat/audio/source/SpotifyPlaylistSourceManager.java
+++ b/FredBoat/src/main/java/fredboat/audio/source/SpotifyPlaylistSourceManager.java
@@ -52,18 +52,17 @@ public class SpotifyPlaylistSourceManager implements AudioSourceManager {
 
         final SpotifyAPIWrapper saw = SpotifyAPIWrapper.getApi();
 
-        String[] plData = new String[0];
+        String[] plData;
         try {
             plData = saw.getPlaylistData(spotifyUser, spotifyListId);
         } catch (Exception e) {
-            log.warn("Could not retrieve playlist " + spotifyListId + " of user " + spotifyUser);
+            log.warn("Could not retrieve playlist " + spotifyListId + " of user " + spotifyUser, e);
             throw new FriendlyException("Couldn't load playlist. Either Spotify is down or the playlist does not exist.", FriendlyException.Severity.COMMON, e);
         }
 
         String playlistName = plData[0];
         if (playlistName == null || "".equals(playlistName)) playlistName = "Spotify Playlist";
         String tracksTotal = plData[1];
-        log.debug("Retrieved playlist data for " + playlistName + " from Spotify with " + tracksTotal + " tracks");
 
         final List<AudioTrack> trackList = new ArrayList<>();
         final List<String> trackListSearchTerms;
@@ -71,9 +70,10 @@ public class SpotifyPlaylistSourceManager implements AudioSourceManager {
         try {
             trackListSearchTerms = saw.getPlaylistTracksSearchTerms(spotifyUser, spotifyListId);
         } catch (Exception e) {
-            log.warn("Could not retrieve tracks for playlist " + spotifyListId + " of user " + spotifyUser);
+            log.warn("Could not retrieve tracks for playlist " + spotifyListId + " of user " + spotifyUser, e);
             throw new FriendlyException("Couldn't load playlist. Either Spotify is down or the playlist does not exist.", FriendlyException.Severity.COMMON, e);
         }
+        log.info("Retrieved playlist data for " + playlistName + " from Spotify, loading up " + tracksTotal + " tracks");
 
         for (final String s : trackListSearchTerms) {
 

--- a/FredBoat/src/main/java/fredboat/audio/source/SpotifyPlaylistSourceManager.java
+++ b/FredBoat/src/main/java/fredboat/audio/source/SpotifyPlaylistSourceManager.java
@@ -1,0 +1,121 @@
+package fredboat.audio.source;
+
+import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
+import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.track.*;
+import com.wrapper.spotify.models.Playlist;
+import com.wrapper.spotify.models.PlaylistTrack;
+import com.wrapper.spotify.models.SimpleArtist;
+import com.wrapper.spotify.models.Track;
+import fredboat.util.SpotifyAPIWrapper;
+import fredboat.util.YoutubeAPI;
+import org.json.JSONException;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Created by napster on 08.03.17.
+ *
+ * @author napster
+ */
+public class SpotifyPlaylistSourceManager implements AudioSourceManager {
+
+    private static final org.slf4j.Logger log = LoggerFactory.getLogger(SpotifyPlaylistSourceManager.class);
+
+    //https://regex101.com/r/AEWyxi/1
+    private static final Pattern PLAYLIST_PATTERN = Pattern.compile("^https?://.*\\.spotify\\.com/user/(.*)/playlist/(.*)$");
+
+
+    @Override
+    public String getSourceName() {
+        return "spotify_playlist_import";
+    }
+
+    @Override
+    public AudioItem loadItem(final DefaultAudioPlayerManager manager, final AudioReference ar) {
+        final Matcher m = PLAYLIST_PATTERN.matcher(ar.identifier);
+
+        if (!m.find()) {
+            return null;
+        }
+
+        final String spotifyUser = m.group(1);
+        final String spotifyListId = m.group(2);
+
+        log.info("matched spotify playlist link! user: " + spotifyUser + ", listId: " + spotifyListId);
+
+        final SpotifyAPIWrapper saw = SpotifyAPIWrapper.getApi();
+        final Playlist playlist;
+        try {
+            playlist = saw.getPlaylist(spotifyUser, spotifyListId).get();
+        } catch (final Exception e) {
+            log.error("Could not get playlist " + spotifyListId + " of user " + spotifyUser, e);
+            return null;
+        }
+        log.info("Retrieved playlist " + playlist.getName() + " from spotify with " + playlist.getTracks().getTotal() + " tracks");
+
+        final List<AudioTrack> trackList = new ArrayList<>();
+        for (final PlaylistTrack t : playlist.getTracks().getItems()) {
+            final Track track = t.getTrack();
+            final StringBuilder sb = new StringBuilder();
+            sb.append(track.getName());
+            track.getArtists().forEach((SimpleArtist artist) -> sb.append(" ").append(artist.getName()));
+            String query = sb.toString();
+
+            //remove all punctuation
+            query = query.replaceAll("[.,/#!$%\\^&*;:{}=\\-_`~()]", "");
+
+            final AudioPlaylist list;
+            try {
+                list = YoutubeAPI.searchForVideos(query);
+            } catch (final JSONException e) {
+                log.debug("YouTube search exception", e);
+                continue; //look for the next track
+            }
+            if (list == null || list.getTracks().size() == 0) {
+                continue; //look for the next track TODO: inform about not being able to find a track?
+            }
+            //pick top most result and hope it's what the user wants to listen to
+            trackList.add(list.getTracks().get(0));
+        }
+
+        //TODO does it only load 100 tracks at a time? maybe related to that com.wrapper.spotify.models.Page thing
+        //TODO holding them?
+
+        //TODO: say something as soon as the search starts
+
+        //TODO: play the first track as soon as possible while continuing to search
+
+        //TODO: are ppl being informed properly for all exceptions?
+
+        //TODO: java documentation
+        return new BasicAudioPlaylist(playlist.getName(), trackList, null, false);
+    }
+
+    @Override
+    public boolean isTrackEncodable(final AudioTrack track) {
+        return false;
+    }
+
+    @Override
+    public void encodeTrack(final AudioTrack track, final DataOutput output) throws IOException {
+        throw new UnsupportedOperationException("This source manager is only for loading playlists");
+    }
+
+    @Override
+    public AudioTrack decodeTrack(final AudioTrackInfo trackInfo, final DataInput input) throws IOException {
+        throw new UnsupportedOperationException("This source manager is only for loading playlists");
+    }
+
+    @Override
+    public void shutdown() {
+
+    }
+}

--- a/FredBoat/src/main/java/fredboat/util/SearchUtil.java
+++ b/FredBoat/src/main/java/fredboat/util/SearchUtil.java
@@ -12,6 +12,7 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 public class SearchUtil {
 
     private static final AudioPlayerManager PLAYER_MANAGER = initPlayerManager();
+    private static final int DEFAULT_TIMEOUT = 3000;
 
     private static AudioPlayerManager initPlayerManager() {
         DefaultAudioPlayerManager manager = new DefaultAudioPlayerManager();
@@ -21,7 +22,11 @@ public class SearchUtil {
     }
 
     public static AudioPlaylist searchForTracks(SearchProvider provider, String query) {
-        return new SearchResultHandler().searchSync(provider, query);
+        return searchForTracks(provider, query, DEFAULT_TIMEOUT);
+    }
+
+    public static AudioPlaylist searchForTracks(SearchProvider provider, String query, int timeout) {
+        return new SearchResultHandler().searchSync(provider, query, timeout);
     }
 
     public enum SearchProvider {
@@ -46,11 +51,11 @@ public class SearchUtil {
         AudioPlaylist result;
         final Object toBeNotified = new Object();
 
-        AudioPlaylist searchSync(SearchProvider provider, String query) {
+        AudioPlaylist searchSync(SearchProvider provider, String query, int timeout) {
             try {
                 synchronized (toBeNotified) {
                     PLAYER_MANAGER.loadItem(provider.getPrefix() + query, this);
-                    toBeNotified.wait(3000);
+                    toBeNotified.wait(timeout);
                 }
             } catch (InterruptedException e) {
                 throw new RuntimeException("Was interrupted while searching", e);

--- a/FredBoat/src/main/java/fredboat/util/SpotifyAPIWrapper.java
+++ b/FredBoat/src/main/java/fredboat/util/SpotifyAPIWrapper.java
@@ -107,7 +107,7 @@ public class SpotifyAPIWrapper {
      * @param playlistId Spotify playlist identifier
      * @return an array containing information about the requested spotify playlist
      */
-    public PlaylistInfo getPlaylistData(String userId, String playlistId) throws UnirestException, JSONException {
+    public PlaylistInfo getPlaylistDataBlocking(String userId, String playlistId) throws UnirestException, JSONException {
         refreshTokenIfNecessary();
 
         JSONObject jsonPlaylist = Unirest.get(URL_SPOTIFY_API + "/v1/users/" + userId + "/playlists/" + playlistId)
@@ -124,12 +124,11 @@ public class SpotifyAPIWrapper {
     }
 
     /**
-     *
      * @param userId Spotify user id of the owner of the requested playlist
      * @param playlistId Spotify playlist identifier
      * @return a string for each track on the requested playlist, containing track and artist names
      */
-    public List<String> getPlaylistTracksSearchTerms(String userId, String playlistId) throws UnirestException, JSONException {
+    public List<String> getPlaylistTracksSearchTermsBlocking(String userId, String playlistId) throws UnirestException, JSONException {
         refreshTokenIfNecessary();
 
         //strings on this list will contain name of the track + names of the artists
@@ -190,87 +189,4 @@ public class SpotifyAPIWrapper {
 
         return list;
     }
-
-    // if that api project ever gets updated this code may come in handy
-    // https://github.com/thelinmichael/spotify-web-api-java
-//    private SettableFuture<ClientCredentials> refreshAccessToken() {
-//
-//        final SettableFuture<ClientCredentials> responseFuture = this.spotifyApi.clientCredentialsGrant().build().getAsync();
-//
-//        Futures.addCallback(responseFuture, new FutureCallback<ClientCredentials>() {
-//            @Override
-//            public void onSuccess(final ClientCredentials cc) {
-//                accessToken = cc.getAccessToken();
-//                SpotifyAPIWrapper.this.spotifyApi.setAccessToken(accessToken);
-//                SpotifyAPIWrapper.this.accessTokenExpires = System.currentTimeMillis() + (cc.getExpiresIn() * 1000);
-//                log.info("Received spotify access token " + cc.getAccessToken() + " expiring in " + cc.getExpiresIn() + " seconds");
-//                log.debug("Retrieved spotify access token " + cc.getAccessToken() + " expiring in " + cc.getExpiresIn() + " seconds");
-//            }
-//
-//            @Override
-//            public void onFailure(final Throwable throwable) {
-//                log.error("Could not request spotify access token", throwable);
-//            }
-//        });
-//
-//        return responseFuture;
-//    }
-//
-//    /**
-//     * @param userId identifier of the spotify user which this list belongs to
-//     * @param listId identifier of requested requested playlist
-//     * @return a Future on the requested playlist
-//     */
-//    public Future<Playlist> getPlaylist(final String userId, final String listId) {
-//        final PlaylistRequest request = this.spotifyApi.getPlaylist(userId, listId).build();
-//        refreshTokenIfNecessary();
-//        return request.getAsync();
-//    }
-//
-//
-//    /**
-//     * Returns the full tracklist of a playlist
-//     *
-//     * @param playlist playlist for which the full tracklist shall be retrieved
-//     * @return a list containing all tracks of the provided playlist
-//     */
-//    public List<PlaylistTrack> getFullTrackList(final Playlist playlist) {
-//        final List<PlaylistTrack> result = new ArrayList<>();
-//        Page<PlaylistTrack> page = null;
-//
-//        do {
-//            final PlaylistTracksRequest.Builder builder = this.spotifyApi.getPlaylistTracks(playlist.getOwner().getId(), playlist.getId());
-//
-//            //this should be true in every iteration except for the first one, where we also don't need to set any parameters
-//            if (page != null) {
-//                final String nextPageUrl = page.getNext();
-//                final Matcher m = PARAMETER_PATTERN.matcher(nextPageUrl);
-//
-//                if (!m.find()) {
-//                    log.debug("Did not find parameter pattern in next page URL provided by Spotify");
-//                    break;
-//                }
-//
-//                final String offset = m.group(1);
-//                final String limit = m.group(2);
-//
-//                //We are trusting Spotify to get their shit together and provide us sane values for these
-//                builder.parameter("offset", offset);
-//                builder.parameter("limit", limit);
-//            }
-//
-//            final PlaylistTracksRequest request = builder.build();
-//            try {
-//                refreshTokenIfNecessary();
-//                page = request.get();
-//                result.addAll(page.getItems());
-//            } catch (final Exception e) {
-//                log.error("Could not get next page in Spotify playlist " + playlist.getId(), e);
-//                break;
-//            }
-//
-//        } while (page.getNext() != null);
-//
-//        return result;
-//    }
 }

--- a/FredBoat/src/main/java/fredboat/util/SpotifyAPIWrapper.java
+++ b/FredBoat/src/main/java/fredboat/util/SpotifyAPIWrapper.java
@@ -6,6 +6,7 @@ import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import com.mashape.unirest.request.HttpRequest;
 import fredboat.Config;
+import fredboat.audio.queue.PlaylistInfo;
 import org.apache.commons.codec.binary.Base64;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -106,12 +107,8 @@ public class SpotifyAPIWrapper {
      * @param playlistId Spotify playlist identifier
      * @return an array containing information about the requested spotify playlist
      */
-    public String[] getPlaylistData(String userId, String playlistId) throws UnirestException, JSONException {
+    public PlaylistInfo getPlaylistData(String userId, String playlistId) throws UnirestException, JSONException {
         refreshTokenIfNecessary();
-
-        String[] result = new String[2];
-        result[0] = "";
-        result[1] = "0";
 
         JSONObject jsonPlaylist = Unirest.get(URL_SPOTIFY_API + "/v1/users/" + userId + "/playlists/" + playlistId)
                     .header("Authorization", "Bearer " + accessToken)
@@ -120,10 +117,10 @@ public class SpotifyAPIWrapper {
                     .getObject();
 
         // https://developer.spotify.com/web-api/object-model/#playlist-object-full
-        result[0] = jsonPlaylist.getString("name");
-        result[1] = jsonPlaylist.getJSONObject("tracks").getInt("total") + "";
+        String name = jsonPlaylist.getString("name");
+        int tracks = jsonPlaylist.getJSONObject("tracks").getInt("total");
 
-        return result;
+        return new PlaylistInfo(tracks, name, PlaylistInfo.Source.SPOTIFY);
     }
 
     /**

--- a/FredBoat/src/main/java/fredboat/util/SpotifyAPIWrapper.java
+++ b/FredBoat/src/main/java/fredboat/util/SpotifyAPIWrapper.java
@@ -5,38 +5,61 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.SettableFuture;
 import com.wrapper.spotify.Api;
 import com.wrapper.spotify.methods.PlaylistRequest;
+import com.wrapper.spotify.methods.PlaylistTracksRequest;
 import com.wrapper.spotify.models.ClientCredentials;
+import com.wrapper.spotify.models.Page;
 import com.wrapper.spotify.models.Playlist;
+import com.wrapper.spotify.models.PlaylistTrack;
 import fredboat.Config;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Future;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Created by napster on 08.03.17.
  *
  * @author napster
+ *
+ * When expanding this class, make sure to call refreshTokenIfNecessary() before every request
  */
 public class SpotifyAPIWrapper {
 
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(SpotifyAPIWrapper.class);
-
     private static SpotifyAPIWrapper SPOTIFYAPIWRAPPER;
 
+    //https://regex101.com/r/FkknVc/1
+    private static final Pattern PARAMETER_PATTERN = Pattern.compile("offset=([0-9]*)&limit=([0-9]*)$");
+
+    /**
+     * This should be the only way to grab a handle on this class.
+     * //TODO is the Singleton pattern really a good idea for production, or does FredBoat need a different design?
+     *
+     * @return the singleton of the Spotify API
+     */
     public static SpotifyAPIWrapper getApi() {
         if (SPOTIFYAPIWRAPPER == null) {
             SPOTIFYAPIWRAPPER = new SpotifyAPIWrapper(Config.CONFIG.getSpotifyId(), Config.CONFIG.getSpotifySecret());
         }
-
         return SPOTIFYAPIWRAPPER;
     }
 
 
-    private Api spotifyApi;
+    private final Api spotifyApi;
     private long accessTokenExpires = 0;
 
-    private SpotifyAPIWrapper(String clientId, String clientSecret) {
-        spotifyApi = Api.builder()
+    /**
+     * Get an instance of this class by using SpotifyAPIWrapper.getApi()
+     */
+    private SpotifyAPIWrapper() {
+        this.spotifyApi = Api.builder().build();
+    }
+
+    private SpotifyAPIWrapper(final String clientId, final String clientSecret) {
+        this.spotifyApi = Api.builder()
                 .clientId(clientId)
                 .clientSecret(clientSecret)
                 .build();
@@ -44,20 +67,23 @@ public class SpotifyAPIWrapper {
         getFreshAccessToken();
     }
 
+    /**
+     * This is related to the client credentials flow.
+     */
     private SettableFuture<ClientCredentials> getFreshAccessToken() {
 
-        final SettableFuture<ClientCredentials> responseFuture = spotifyApi.clientCredentialsGrant().build().getAsync();
+        final SettableFuture<ClientCredentials> responseFuture = this.spotifyApi.clientCredentialsGrant().build().getAsync();
 
         Futures.addCallback(responseFuture, new FutureCallback<ClientCredentials>() {
             @Override
-            public void onSuccess(ClientCredentials cc) {
-                spotifyApi.setAccessToken(cc.getAccessToken());
-                accessTokenExpires = System.currentTimeMillis() + (cc.getExpiresIn() * 1000);
-                log.info("Retrieved spotify access token. Expires in " + cc.getExpiresIn() + " seconds");
+            public void onSuccess(final ClientCredentials cc) {
+                SpotifyAPIWrapper.this.spotifyApi.setAccessToken(cc.getAccessToken());
+                SpotifyAPIWrapper.this.accessTokenExpires = System.currentTimeMillis() + (cc.getExpiresIn() * 1000);
+                log.debug("Retrieved spotify access token. Expires in " + cc.getExpiresIn() + " seconds");
             }
 
             @Override
-            public void onFailure(Throwable throwable) {
+            public void onFailure(final Throwable throwable) {
                 log.error("Could not request spotify access token", throwable);
             }
         });
@@ -65,18 +91,73 @@ public class SpotifyAPIWrapper {
         return responseFuture;
     }
 
-
-    public Future<Playlist> getPlaylist(String userId, String listId) {
-
+    /**
+     * Call this before doing any requests
+     */
+    private void refreshTokenIfNecessary() {
         //refresh the token if it's too old
-        if (System.currentTimeMillis() > accessTokenExpires) try {
+        if (System.currentTimeMillis() > this.accessTokenExpires) try {
             getFreshAccessToken().get();
-        } catch (Exception e) {
+        } catch (final Exception e) {
             log.error("Could not request spotify access token", e);
         }
+    }
 
-        final PlaylistRequest request = spotifyApi.getPlaylist(userId, listId).build();
-
+    /**
+     * @param userId identifier of the spotify user which this list belongs to
+     * @param listId identifier of requested requested playlist
+     * @return a Future on the requested playlist
+     */
+    public Future<Playlist> getPlaylist(final String userId, final String listId) {
+        final PlaylistRequest request = this.spotifyApi.getPlaylist(userId, listId).build();
+        refreshTokenIfNecessary();
         return request.getAsync();
+    }
+
+
+    /**
+     * Returns the full tracklist of a playlist
+     *
+     * @param playlist playlist for which the full tracklist shall be retrieved
+     * @return a list containing all tracks of the provided playlist
+     */
+    public List<PlaylistTrack> getFullTrackList(final Playlist playlist) {
+        final List<PlaylistTrack> result = new ArrayList<>();
+        Page<PlaylistTrack> page = null;
+
+        do {
+            final PlaylistTracksRequest.Builder builder = this.spotifyApi.getPlaylistTracks(playlist.getOwner().getId(), playlist.getId());
+
+            //this should be true in every iteration except for the first one, where we also don't need to set any parameters
+            if (page != null) {
+                final String nextPageUrl = page.getNext();
+                final Matcher m = PARAMETER_PATTERN.matcher(nextPageUrl);
+
+                if (!m.find()) {
+                    log.debug("Did not find parameter pattern in next page URL provided by Spotify");
+                    break;
+                }
+
+                final String offset = m.group(1);
+                final String limit = m.group(2);
+
+                //We are trusting Spotify to get their shit together and provide us sane values for these
+                builder.parameter("offset", offset);
+                builder.parameter("limit", limit);
+            }
+
+            final PlaylistTracksRequest request = builder.build();
+            try {
+                refreshTokenIfNecessary();
+                page = request.get();
+                result.addAll(page.getItems());
+            } catch (final Exception e) {
+                log.error("Could not get next page in Spotify playlist " + playlist.getId(), e);
+                break;
+            }
+
+        } while (page.getNext() != null);
+
+        return result;
     }
 }

--- a/FredBoat/src/main/java/fredboat/util/SpotifyAPIWrapper.java
+++ b/FredBoat/src/main/java/fredboat/util/SpotifyAPIWrapper.java
@@ -1,0 +1,82 @@
+package fredboat.util;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
+import com.wrapper.spotify.Api;
+import com.wrapper.spotify.methods.PlaylistRequest;
+import com.wrapper.spotify.models.ClientCredentials;
+import com.wrapper.spotify.models.Playlist;
+import fredboat.Config;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Future;
+
+/**
+ * Created by napster on 08.03.17.
+ *
+ * @author napster
+ */
+public class SpotifyAPIWrapper {
+
+    private static final org.slf4j.Logger log = LoggerFactory.getLogger(SpotifyAPIWrapper.class);
+
+    private static SpotifyAPIWrapper SPOTIFYAPIWRAPPER;
+
+    public static SpotifyAPIWrapper getApi() {
+        if (SPOTIFYAPIWRAPPER == null) {
+            SPOTIFYAPIWRAPPER = new SpotifyAPIWrapper(Config.CONFIG.getSpotifyId(), Config.CONFIG.getSpotifySecret());
+        }
+
+        return SPOTIFYAPIWRAPPER;
+    }
+
+
+    private Api spotifyApi;
+    private long accessTokenExpires = 0;
+
+    private SpotifyAPIWrapper(String clientId, String clientSecret) {
+        spotifyApi = Api.builder()
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .build();
+
+        getFreshAccessToken();
+    }
+
+    private SettableFuture<ClientCredentials> getFreshAccessToken() {
+
+        final SettableFuture<ClientCredentials> responseFuture = spotifyApi.clientCredentialsGrant().build().getAsync();
+
+        Futures.addCallback(responseFuture, new FutureCallback<ClientCredentials>() {
+            @Override
+            public void onSuccess(ClientCredentials cc) {
+                spotifyApi.setAccessToken(cc.getAccessToken());
+                accessTokenExpires = System.currentTimeMillis() + (cc.getExpiresIn() * 1000);
+                log.info("Retrieved spotify access token. Expires in " + cc.getExpiresIn() + " seconds");
+            }
+
+            @Override
+            public void onFailure(Throwable throwable) {
+                log.error("Could not request spotify access token", throwable);
+            }
+        });
+
+        return responseFuture;
+    }
+
+
+    public Future<Playlist> getPlaylist(String userId, String listId) {
+
+        //refresh the token if it's too old
+        if (System.currentTimeMillis() > accessTokenExpires) try {
+            getFreshAccessToken().get();
+        } catch (Exception e) {
+            log.error("Could not request spotify access token", e);
+        }
+
+        final PlaylistRequest request = spotifyApi.getPlaylist(userId, listId).build();
+
+        return request.getAsync();
+    }
+}

--- a/FredBoat/src/main/java/fredboat/util/SpotifyAPIWrapper.java
+++ b/FredBoat/src/main/java/fredboat/util/SpotifyAPIWrapper.java
@@ -147,7 +147,7 @@ public class SpotifyAPIWrapper {
             //this determines offset and limit on the 2nd+ pass of the do loop
             if (jsonPage != null) {
                 String nextPageUrl;
-                if (!jsonPage.has("next") || jsonPage.getString("next") == null) break;
+                if (!jsonPage.has("next") || jsonPage.get("next") == JSONObject.NULL) break;
                 nextPageUrl = jsonPage.getString("next");
 
                 final Matcher m = PARAMETER_PATTERN.matcher(nextPageUrl);


### PR DESCRIPTION
Adds Spotify playlist support

This should close #74


When reviewing this, please watch out whether this PR is in line with the existing conventions for FredBoat, especially when to do/not to do sync/async requests. I am not 100% sure I adhered to your standards, though I tried :)

I am also not sure if the Singleton pattern used in `SpotifyAPIWrapper` is the correct way to go for FredBoat in production, or if we need to shard it or whatever.


Improvements/ideas I have left after doing this:
- Make it so that `;;play <spotifyplaylist>` loads the tracks primarily from Youtube with SoundCloud as backup, and `;;sc <spotifyplaylist>` loads the tracks primarily from SoundCloud with Youtube as a backup search source. This would probably require adding more information to this call in `PlayCommand.java`:
```
player.queue(args[1], channel, invoker);
```

- Long playlists take ages to load (same is true for playlists loaded through Hastebin). Letting the user know with a short message that the bot is working on it would make this bearable and the user experience a bit smoother. The optimal scenario would be to have the first track play while the others are being loaded. I had trouble getting a handle on the invoker of the playlist command in the `SpotifyPlaylistSourceManager` class to send out such a message (and a few other informational ones which should help users of the bot with any unexpected behaviour). My first idea would be to extend the `AudioReference` class and add some information to it about the requester of the song (and maybe the desired search provider, see first idea) so that we can access that info during the `loadItem()` method in the SourceManagers. Let me know if this sounds sane and in line with your plans, then I could maybe look into implementing that.