### PR TITLE
Repeat whole playlist added

### DIFF
--- a/FredBoat/src/main/java/fredboat/Config.java
+++ b/FredBoat/src/main/java/fredboat/Config.java
@@ -84,6 +84,9 @@ public class Config {
             configFileStr = configFileStr.replaceAll("\t", "");
             Map<String, Object> creds = (Map<String, Object>) yaml.load(credsFileStr);
             Map<String, Object> config = (Map<String, Object>) yaml.load(configFileStr);
+            //avoid null values, rather change them to empty strings
+            creds.keySet().forEach((String key) -> creds.putIfAbsent(key, ""));
+            config.keySet().forEach((String key) -> config.putIfAbsent(key, ""));
 
 
             // Determine distribution

--- a/FredBoat/src/main/java/fredboat/audio/GuildPlayer.java
+++ b/FredBoat/src/main/java/fredboat/audio/GuildPlayer.java
@@ -28,10 +28,7 @@ package fredboat.audio;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason;
-import fredboat.audio.queue.AudioLoader;
-import fredboat.audio.queue.AudioTrackContext;
-import fredboat.audio.queue.IdentifierContext;
-import fredboat.audio.queue.SimpleTrackProvider;
+import fredboat.audio.queue.*;
 import fredboat.commandmeta.MessagingException;
 import fredboat.db.DatabaseNotReadyException;
 import fredboat.db.EntityReader;
@@ -234,19 +231,21 @@ public class GuildPlayer extends AbstractPlayer {
         return jda.getGuildById(guildId);
     }
 
-    public boolean isRepeat() {
-        return audioTrackProvider instanceof SimpleTrackProvider && ((SimpleTrackProvider) audioTrackProvider).isRepeat();
+    public RepeatMode getRepeatMode() {
+        if (audioTrackProvider instanceof AbstractTrackProvider)
+            return ((AbstractTrackProvider) audioTrackProvider).getRepeatMode();
+        else return RepeatMode.OFF;
     }
 
     public boolean isShuffle() {
         return audioTrackProvider instanceof SimpleTrackProvider && ((SimpleTrackProvider) audioTrackProvider).isShuffle();
     }
 
-    public void setRepeat(boolean repeat) {
-        if (audioTrackProvider instanceof SimpleTrackProvider) {
-            ((SimpleTrackProvider) audioTrackProvider).setRepeat(repeat);
+    public void setRepeatMode(RepeatMode repeatMode) {
+        if (audioTrackProvider instanceof AbstractTrackProvider) {
+            ((AbstractTrackProvider) audioTrackProvider).setRepeatMode(repeatMode);
         } else {
-            throw new UnsupportedOperationException("Can't repeat or shuffle " + audioTrackProvider.getClass());
+            throw new UnsupportedOperationException("Can't repeat " + audioTrackProvider.getClass());
         }
     }
 
@@ -254,7 +253,7 @@ public class GuildPlayer extends AbstractPlayer {
         if (audioTrackProvider instanceof SimpleTrackProvider) {
             ((SimpleTrackProvider) audioTrackProvider).setShuffle(shuffle);
         } else {
-            throw new UnsupportedOperationException("Can't repeat or shuffle " + audioTrackProvider.getClass());
+            throw new UnsupportedOperationException("Can't shuffle " + audioTrackProvider.getClass());
         }
     }
 
@@ -335,7 +334,7 @@ public class GuildPlayer extends AbstractPlayer {
 
         if((endReason == AudioTrackEndReason.FINISHED || endReason == AudioTrackEndReason.STOPPED)
                 && getPlayingTrack() != null
-                && !isRepeat()
+                && getRepeatMode() != RepeatMode.SINGLE
                 && isTrackAnnounceEnabled()){
             getActiveTextChannel().sendMessage(MessageFormat.format(I18n.get(getGuild()).getString("trackAnnounce"), getPlayingTrack().getEffectiveTitle())).queue();
         }

--- a/FredBoat/src/main/java/fredboat/audio/GuildPlayer.java
+++ b/FredBoat/src/main/java/fredboat/audio/GuildPlayer.java
@@ -257,6 +257,14 @@ public class GuildPlayer extends AbstractPlayer {
         }
     }
 
+    public void reshuffle() {
+        if (audioTrackProvider instanceof SimpleTrackProvider) {
+            ((SimpleTrackProvider) audioTrackProvider).reshuffle();
+        } else {
+            throw new UnsupportedOperationException("Can't reshuffle " + audioTrackProvider.getClass());
+        }
+    }
+
     public void setCurrentTC(TextChannel currentTC) {
         this.currentTC = currentTC;
     }

--- a/FredBoat/src/main/java/fredboat/audio/MusicPersistenceHandler.java
+++ b/FredBoat/src/main/java/fredboat/audio/MusicPersistenceHandler.java
@@ -31,6 +31,7 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import fredboat.Config;
 import fredboat.FredBoat;
 import fredboat.audio.queue.AudioTrackContext;
+import fredboat.audio.queue.RepeatMode;
 import fredboat.audio.queue.SplitAudioTrackContext;
 import fredboat.feature.I18n;
 import fredboat.util.DistributionEnum;
@@ -96,7 +97,7 @@ public class MusicPersistenceHandler {
                 data.put("tc", player.getActiveTextChannel().getId());
                 data.put("isPaused", player.isPaused());
                 data.put("volume", Float.toString(player.getVolume()));
-                data.put("repeat", player.isRepeat());
+                data.put("repeatMode", player.getRepeatMode());
                 data.put("shuffle", player.isShuffle());
 
                 if (player.getPlayingTrack() != null) {
@@ -172,7 +173,7 @@ public class MusicPersistenceHandler {
                 VoiceChannel vc = FredBoat.getVoiceChannelById(data.getString("vc"));
                 TextChannel tc = FredBoat.getTextChannelById(data.getString("tc"));
                 float volume = Float.parseFloat(data.getString("volume"));
-                boolean repeat = data.getBoolean("repeat");
+                RepeatMode repeatMode = data.getEnum(RepeatMode.class, "repeatMode");
                 boolean shuffle = data.getBoolean("shuffle");
 
                 GuildPlayer player = PlayerRegistry.get(vc.getJDA(), gId);
@@ -182,7 +183,7 @@ public class MusicPersistenceHandler {
                 if(Config.CONFIG.getDistribution().volumeSupported()) {
                     player.setVolume(volume);
                 }
-                player.setRepeat(repeat);
+                player.setRepeatMode(repeatMode);
                 player.setShuffle(shuffle);
 
                 final boolean[] isFirst = {true};

--- a/FredBoat/src/main/java/fredboat/audio/queue/AbstractTrackProvider.java
+++ b/FredBoat/src/main/java/fredboat/audio/queue/AbstractTrackProvider.java
@@ -29,19 +29,19 @@ import java.util.List;
 
 public abstract class AbstractTrackProvider implements ITrackProvider {
 
-    private boolean repeat = false;
+    private RepeatMode repeatMode = RepeatMode.OFF;
     private boolean shuffle = false;
 
-    public boolean isRepeat() {
-        return repeat;
+    public RepeatMode getRepeatMode() {
+        return repeatMode;
     }
 
     public boolean isShuffle() {
         return shuffle;
     }
 
-    public void setRepeat(boolean repeat) {
-        this.repeat = repeat;
+    public void setRepeatMode(RepeatMode repeatMode) {
+        this.repeatMode = repeatMode;
     }
 
     public void setShuffle(boolean shuffle) {

--- a/FredBoat/src/main/java/fredboat/audio/queue/AudioTrackContext.java
+++ b/FredBoat/src/main/java/fredboat/audio/queue/AudioTrackContext.java
@@ -67,6 +67,10 @@ public class AudioTrackContext implements Comparable<AudioTrackContext> {
         return rand;
     }
 
+    public void setRand(int rand) {
+        this.rand = rand;
+    }
+
     public int randomize() {
         rand = new Random().nextInt();
         return rand;

--- a/FredBoat/src/main/java/fredboat/audio/queue/RepeatMode.java
+++ b/FredBoat/src/main/java/fredboat/audio/queue/RepeatMode.java
@@ -1,0 +1,14 @@
+package fredboat.audio.queue;
+
+/**
+ * Created by napster on 11.03.17.
+ * <p>
+ * Describes the possible repeat modes
+ * <p>
+ * OFF = no repeat is happening
+ * SINGLE = the top most song in the queue is repeated
+ * ALL = the whole queue is repeated.
+ */
+public enum RepeatMode {
+    OFF, SINGLE, ALL
+}

--- a/FredBoat/src/main/java/fredboat/audio/queue/SimpleTrackProvider.java
+++ b/FredBoat/src/main/java/fredboat/audio/queue/SimpleTrackProvider.java
@@ -143,6 +143,11 @@ public class SimpleTrackProvider extends AbstractTrackProvider {
         if (shuffle) shouldUpdateShuffledQueue = true;
     }
 
+    public synchronized void reshuffle() {
+        queue.forEach(AudioTrackContext::randomize);
+        shouldUpdateShuffledQueue = true;
+    }
+
     @Override
     public synchronized List<AudioTrackContext> getAsListOrdered() {
         if (!isShuffle()) {

--- a/FredBoat/src/main/java/fredboat/command/music/control/RepeatCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/RepeatCommand.java
@@ -25,8 +25,10 @@
 
 package fredboat.command.music.control;
 
+import fredboat.Config;
 import fredboat.audio.GuildPlayer;
 import fredboat.audio.PlayerRegistry;
+import fredboat.audio.queue.RepeatMode;
 import fredboat.commandmeta.abs.Command;
 import fredboat.commandmeta.abs.IMusicCommand;
 import fredboat.feature.I18n;
@@ -35,18 +37,55 @@ import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.Message;
 import net.dv8tion.jda.core.entities.TextChannel;
 
+import java.text.MessageFormat;
+
 public class RepeatCommand extends Command implements IMusicCommand {
 
     @Override
     public void onInvoke(Guild guild, TextChannel channel, Member invoker, Message message, String[] args) {
         GuildPlayer player = PlayerRegistry.get(guild);
-        player.setRepeat(!player.isRepeat());
 
-        if (player.isRepeat()) {
-            channel.sendMessage(I18n.get(guild).getString("repeatOn")).queue();
-        } else {
-            channel.sendMessage(I18n.get(guild).getString("repeatOff")).queue();
+        if (args.length < 2) {
+            channel.sendMessage(MessageFormat.format(I18n.get(guild).getString("repeatHelp"), Config.CONFIG.getPrefix())).queue();
+            return;
+        }
+
+        RepeatMode desiredRepeatMode;
+        String userInput = args[1];
+        switch (userInput) {
+            case "off":
+            case "out":
+                desiredRepeatMode = RepeatMode.OFF;
+                break;
+            case "single":
+            case "one":
+            case "track":
+                desiredRepeatMode = RepeatMode.SINGLE;
+                break;
+            case "all":
+            case "list":
+            case "queue":
+                desiredRepeatMode = RepeatMode.ALL;
+                break;
+            case "help":
+            default:
+                channel.sendMessage(MessageFormat.format(I18n.get(guild).getString("repeatHelp"), Config.CONFIG.getPrefix())).queue();
+                return;
+        }
+
+
+        player.setRepeatMode(desiredRepeatMode);
+
+        switch (desiredRepeatMode) {
+            case OFF:
+                channel.sendMessage(I18n.get(guild).getString("repeatOff")).queue();
+                break;
+            case SINGLE:
+                channel.sendMessage(I18n.get(guild).getString("repeatOnSingle")).queue();
+                break;
+            case ALL:
+                channel.sendMessage(I18n.get(guild).getString("repeatOnAll")).queue();
+                break;
         }
     }
-
 }

--- a/FredBoat/src/main/java/fredboat/command/music/control/ReshuffleCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/ReshuffleCommand.java
@@ -1,0 +1,24 @@
+package fredboat.command.music.control;
+
+import fredboat.audio.PlayerRegistry;
+import fredboat.commandmeta.abs.Command;
+import fredboat.commandmeta.abs.IMusicCommand;
+import fredboat.feature.I18n;
+import net.dv8tion.jda.core.entities.Guild;
+import net.dv8tion.jda.core.entities.Member;
+import net.dv8tion.jda.core.entities.Message;
+import net.dv8tion.jda.core.entities.TextChannel;
+
+/**
+ * Created by napster on 17.03.17.
+ * <p>
+ * This command allows its user to request a reshuffle of the shuffled playlist
+ */
+public class ReshuffleCommand extends Command implements IMusicCommand {
+
+    @Override
+    public void onInvoke(Guild guild, TextChannel channel, Member invoker, Message message, String[] args) {
+        PlayerRegistry.get(guild).reshuffle();
+        channel.sendMessage(I18n.get(guild).getString("reshufflePlaylist")).queue();
+    }
+}

--- a/FredBoat/src/main/java/fredboat/command/music/control/ReshuffleCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/ReshuffleCommand.java
@@ -1,9 +1,11 @@
 package fredboat.command.music.control;
 
+import fredboat.audio.GuildPlayer;
 import fredboat.audio.PlayerRegistry;
 import fredboat.commandmeta.abs.Command;
 import fredboat.commandmeta.abs.IMusicCommand;
 import fredboat.feature.I18n;
+import fredboat.util.TextUtils;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.Message;
@@ -18,7 +20,12 @@ public class ReshuffleCommand extends Command implements IMusicCommand {
 
     @Override
     public void onInvoke(Guild guild, TextChannel channel, Member invoker, Message message, String[] args) {
-        PlayerRegistry.get(guild).reshuffle();
+        GuildPlayer player = PlayerRegistry.get(guild);
+        if (!player.isShuffle()) {
+            TextUtils.replyWithName(channel, invoker, I18n.get(guild).getString("reshufflePlayerNotShuffling"));
+            return;
+        }
+        player.reshuffle();
         channel.sendMessage(I18n.get(guild).getString("reshufflePlaylist")).queue();
     }
 }

--- a/FredBoat/src/main/java/fredboat/command/music/info/ListCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/info/ListCommand.java
@@ -62,8 +62,18 @@ public class ListCommand extends Command implements IMusicCommand {
 
             int i = 0;
 
-            if(player.isShuffle()){
-                mb.append(I18n.get(guild).getString("listShowShuffled"));
+            if (player.isShuffle()) {
+                switch (player.getRepeatMode()) {
+                    case SINGLE:
+                        mb.append(I18n.get(guild).getString("listShowShuffledRepeatSingle"));
+                        break;
+                    case ALL:
+                        mb.append(I18n.get(guild).getString("listShowShuffledRepeatAll"));
+                        break;
+                    case OFF:
+                    default:
+                        mb.append(I18n.get(guild).getString("listShowShuffled"));
+                }
             }
 
             for (AudioTrackContext atc : player.getRemainingTracksOrdered()) {

--- a/FredBoat/src/main/java/fredboat/command/music/info/ListCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/info/ListCommand.java
@@ -28,6 +28,7 @@ package fredboat.command.music.info;
 import fredboat.audio.GuildPlayer;
 import fredboat.audio.PlayerRegistry;
 import fredboat.audio.queue.AudioTrackContext;
+import fredboat.audio.queue.RepeatMode;
 import fredboat.commandmeta.abs.Command;
 import fredboat.commandmeta.abs.IMusicCommand;
 import fredboat.feature.I18n;
@@ -63,18 +64,19 @@ public class ListCommand extends Command implements IMusicCommand {
             int i = 0;
 
             if (player.isShuffle()) {
-                switch (player.getRepeatMode()) {
-                    case SINGLE:
-                        mb.append(I18n.get(guild).getString("listShowShuffledRepeatSingle"));
-                        break;
-                    case ALL:
-                        mb.append(I18n.get(guild).getString("listShowShuffledRepeatAll"));
-                        break;
-                    case OFF:
-                    default:
-                        mb.append(I18n.get(guild).getString("listShowShuffled"));
-                }
+                mb.append(I18n.get(guild).getString("listShowShuffled"));
+                mb.append("\n");
+                if (player.getRepeatMode() == RepeatMode.OFF)
+                    mb.append("\n");
             }
+            if (player.getRepeatMode() == RepeatMode.SINGLE) {
+                mb.append(I18n.get(guild).getString("listShowRepeatSingle"));
+                mb.append("\n\n");
+            } else if (player.getRepeatMode() == RepeatMode.ALL) {
+                mb.append(I18n.get(guild).getString("listShowRepeatAll"));
+                mb.append("\n\n");
+            }
+
 
             for (AudioTrackContext atc : player.getRemainingTracksOrdered()) {
                 String status = " ";

--- a/FredBoat/src/main/java/fredboat/commandmeta/init/MusicCommandInitializer.java
+++ b/FredBoat/src/main/java/fredboat/commandmeta/init/MusicCommandInitializer.java
@@ -44,6 +44,7 @@ public class MusicCommandInitializer {
         CommandRegistry.registerCommand("unpause", new UnpauseCommand());
         CommandRegistry.registerCommand("getid", new GetIdCommand());
         CommandRegistry.registerCommand("shuffle", new ShuffleCommand());
+        CommandRegistry.registerCommand("reshuffle", new ReshuffleCommand());
         CommandRegistry.registerCommand("repeat", new RepeatCommand());
         CommandRegistry.registerCommand("volume", new VolumeCommand());
         CommandRegistry.registerAlias("volume", "vol");


### PR DESCRIPTION
related issue: #42

As specified in the issue this adds another repeat mode that will repeat the whole playlist. The handling of the shuffled list has been adapted and is also more consistent now. Additionally, it is now actually shuffled ;-) Before is was using `Collections.sort()` instead of `Collections.shuffle()`.

A message explaining the `repeat` command will be displayed if the command is used in the wrong way.

Language repo has been updated too.