### PR TITLE
Use an executor for the processing of the agents

### DIFF
--- a/FredBoat/src/main/java/fredboat/FredBoat.java
+++ b/FredBoat/src/main/java/fredboat/FredBoat.java
@@ -31,6 +31,7 @@ import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
 import fredboat.agent.CarbonitexAgent;
 import fredboat.agent.DBConnectionWatchdogAgent;
+import fredboat.agent.FredBoatAgent;
 import fredboat.agent.ShardWatchdogAgent;
 import fredboat.api.API;
 import fredboat.audio.player.GuildPlayer;
@@ -93,9 +94,6 @@ public abstract class FredBoat {
 
     JDA jda;
 
-    private static ShardWatchdogAgent shardWatchdogAgent;
-    private static DBConnectionWatchdogAgent dbConnectionWatchdogAgent;
-
     private static DatabaseManager dbManager;
 
     public static void main(String[] args) throws LoginException, IllegalArgumentException, InterruptedException, IOException, UnirestException {
@@ -129,8 +127,7 @@ public abstract class FredBoat {
         if (!Config.CONFIG.getJdbcUrl().equals("")) {
             dbManager = new DatabaseManager(Config.CONFIG.getJdbcUrl(), null, Config.CONFIG.getHikariPoolSize());
             dbManager.startup();
-            dbConnectionWatchdogAgent = new DBConnectionWatchdogAgent(dbManager);
-            dbConnectionWatchdogAgent.start();
+            FredBoatAgent.start(new DBConnectionWatchdogAgent(dbManager));
         } else if (Config.CONFIG.getNumShards() > 2) {
             log.warn("No JDBC URL and more than 2 shard found! Initializing the SQLi DB is potentially dangerous too. Skipping...");
         } else {
@@ -166,14 +163,10 @@ public abstract class FredBoat {
         initBotShards(listenerBot);
 
         if (Config.CONFIG.getDistribution() == DistributionEnum.MUSIC && Config.CONFIG.getCarbonKey() != null) {
-            CarbonitexAgent carbonitexAgent = new CarbonitexAgent(Config.CONFIG.getCarbonKey());
-            carbonitexAgent.setDaemon(true);
-            carbonitexAgent.start();
+            FredBoatAgent.start(new CarbonitexAgent(Config.CONFIG.getCarbonKey()));
         }
 
-        shardWatchdogAgent = new ShardWatchdogAgent();
-        shardWatchdogAgent.setDaemon(true);
-        shardWatchdogAgent.start();
+        FredBoatAgent.start(new ShardWatchdogAgent());
     }
 
     private static boolean hasValidMALLogin() {
@@ -290,8 +283,7 @@ public abstract class FredBoat {
     private static final Runnable ON_SHUTDOWN = () -> {
         int code = shutdownCode != UNKNOWN_SHUTDOWN_CODE ? shutdownCode : -1;
 
-        shardWatchdogAgent.shutdown();
-        if (dbConnectionWatchdogAgent != null) dbConnectionWatchdogAgent.shutdown();
+        FredBoatAgent.shutdown();
 
         try {
             MusicPersistenceHandler.handlePreShutdown(code);

--- a/FredBoat/src/main/java/fredboat/agent/CarbonitexAgent.java
+++ b/FredBoat/src/main/java/fredboat/agent/CarbonitexAgent.java
@@ -31,29 +31,23 @@ import fredboat.FredBoat;
 import net.dv8tion.jda.core.JDA;
 import org.slf4j.LoggerFactory;
 
-public class CarbonitexAgent extends Thread {
+import java.util.concurrent.TimeUnit;
+
+public class CarbonitexAgent extends FredBoatAgent {
 
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(CarbonitexAgent.class);
 
     private final String key;
 
     public CarbonitexAgent(String key) {
-        super(CarbonitexAgent.class.getSimpleName());
+        super("carbonitex", 30, TimeUnit.MINUTES);
         this.key = key;
     }
 
     @Override
-    public void run() {
-        try {
-            //noinspection InfiniteLoopStatement
-            while (true) {
-                synchronized (this) {
-                    sendStats();
-                    sleep(30 * 60 * 1000);
-                }
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+    public void doRun() {
+        synchronized (this) {
+            sendStats();
         }
 
     }

--- a/FredBoat/src/main/java/fredboat/agent/FredBoatAgent.java
+++ b/FredBoat/src/main/java/fredboat/agent/FredBoatAgent.java
@@ -37,7 +37,7 @@ public abstract class FredBoatAgent implements Runnable {
     private static final String IDLE_NAME = "idle agent worker thread";
     private static final String RUNNING_NAME = "%s agent worker thread";
 
-    private static final ScheduledExecutorService AGENTS = Executors.newSingleThreadScheduledExecutor(runnable -> {
+    private static final ScheduledExecutorService AGENTS = Executors.newScheduledThreadPool(2, runnable -> {
         Thread thread = new Thread(runnable, IDLE_NAME);
         thread.setPriority(4);
         return thread;

--- a/FredBoat/src/main/java/fredboat/agent/FredBoatAgent.java
+++ b/FredBoat/src/main/java/fredboat/agent/FredBoatAgent.java
@@ -68,9 +68,9 @@ public abstract class FredBoatAgent implements Runnable {
         LAST_RUN_TIME.put(this.getClass(), System.currentTimeMillis());
         try {
             Thread.currentThread().setName(name);
-            log.info("running");
+            log.debug("running");
             doRun();
-            log.info("done");
+            log.debug("done");
         } catch (Throwable t) {
             log.warn("Whoa! Unhandled throwable!", t);
         } finally {

--- a/FredBoat/src/main/java/fredboat/agent/FredBoatAgent.java
+++ b/FredBoat/src/main/java/fredboat/agent/FredBoatAgent.java
@@ -82,6 +82,7 @@ public abstract class FredBoatAgent implements Runnable {
 
     public static void start(FredBoatAgent agent) {
         AGENTS.scheduleAtFixedRate(agent, agent.millisToSleep, agent.millisToSleep, TimeUnit.MILLISECONDS);
+        LAST_RUN_TIME.put(agent.getClass(), 0L);
     }
 
     public static Map<Class<? extends FredBoatAgent>, Long> getLastRunTimes() {

--- a/FredBoat/src/main/java/fredboat/agent/FredBoatAgent.java
+++ b/FredBoat/src/main/java/fredboat/agent/FredBoatAgent.java
@@ -1,0 +1,82 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 Frederik Ar. Mikkelsen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package fredboat.agent;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public abstract class FredBoatAgent implements Runnable {
+
+    private static final String IDLE_NAME = "idle agent worker thread";
+    private static final String RUNNING_NAME = "%s agent worker thread";
+
+    private static final ScheduledExecutorService AGENTS = Executors.newSingleThreadScheduledExecutor(runnable -> {
+        Thread thread = new Thread(runnable, IDLE_NAME);
+        thread.setPriority(4);
+        return thread;
+    });
+
+    //only one of each agent, non-static is fine
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private final String name;
+    private final long millisToSleep;
+
+    protected FredBoatAgent(String name, long millisToSleep) {
+        this.name = String.format(RUNNING_NAME, name);
+        this.millisToSleep = millisToSleep;
+    }
+
+    protected FredBoatAgent(String name, long timeToSleep, TimeUnit unitToSleep) {
+        this(name, unitToSleep.toMillis(timeToSleep));
+    }
+
+    @Override
+    public final void run() {
+        try {
+            Thread.currentThread().setName(name);
+            log.info("running");
+            doRun();
+            log.info("done");
+        } finally {
+            Thread.currentThread().setName(IDLE_NAME);
+        }
+    }
+
+    protected abstract void doRun();
+
+    public static void start(FredBoatAgent agent) {
+        AGENTS.scheduleAtFixedRate(agent, agent.millisToSleep, agent.millisToSleep, TimeUnit.MILLISECONDS);
+    }
+
+    public static void shutdown() {
+        AGENTS.shutdown();
+    }
+}

--- a/FredBoat/src/main/java/fredboat/agent/FredBoatAgent.java
+++ b/FredBoat/src/main/java/fredboat/agent/FredBoatAgent.java
@@ -65,6 +65,8 @@ public abstract class FredBoatAgent implements Runnable {
             log.info("running");
             doRun();
             log.info("done");
+        } catch (Throwable t) {
+            log.warn("Whoa! Unhandled throwable!", t);
         } finally {
             Thread.currentThread().setName(IDLE_NAME);
         }

--- a/FredBoat/src/main/java/fredboat/agent/VoiceChannelCleanupAgent.java
+++ b/FredBoat/src/main/java/fredboat/agent/VoiceChannelCleanupAgent.java
@@ -38,36 +38,24 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
-public class VoiceChannelCleanupAgent extends Thread {
+public class VoiceChannelCleanupAgent extends FredBoatAgent {
 
     private static final Logger log = LoggerFactory.getLogger(VoiceChannelCleanupAgent.class);
     private static final HashMap<String, Long> VC_LAST_USED = new HashMap<>();
-    private static final int CLEANUP_INTERVAL_MILLIS = 60000 * 10;
     private static final int UNUSED_CLEANUP_THRESHOLD = 60000 * 60; // Effective when users are in the VC, but the player is not playing
 
     public VoiceChannelCleanupAgent() {
-        super("voice-cleanup");
-        setDaemon(true);
-        setPriority(4);
+        super("voice-cleanup", 10, TimeUnit.MINUTES);
     }
 
     @Override
-    public void run() {
-        log.info("Started voice-cleanup");
-        //noinspection InfiniteLoopStatement
-        while (true) {
-            try {
-                cleanup();
-                sleep(CLEANUP_INTERVAL_MILLIS);
-            } catch (Exception e) {
-                log.error("Caught an exception while trying to clean up voice channels!", e);
-                try {
-                    sleep(1000);
-                } catch (InterruptedException e1) {
-                    throw new RuntimeException(e1);
-                }
-            }
+    public void doRun() {
+        try {
+            cleanup();
+        } catch (Exception e) {
+            log.error("Caught an exception while trying to clean up voice channels!", e);
         }
     }
 

--- a/FredBoat/src/main/java/fredboat/command/maintenance/StatsCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/maintenance/StatsCommand.java
@@ -28,6 +28,7 @@ package fredboat.command.maintenance;
 import com.sedmelluq.discord.lavaplayer.tools.PlayerLibrary;
 import fredboat.Config;
 import fredboat.FredBoat;
+import fredboat.agent.FredBoatAgent;
 import fredboat.audio.player.PlayerRegistry;
 import fredboat.commandmeta.CommandManager;
 import fredboat.commandmeta.abs.Command;
@@ -39,6 +40,7 @@ import net.dv8tion.jda.core.JDAInfo;
 import net.dv8tion.jda.core.entities.Guild;
 
 import java.text.MessageFormat;
+import java.util.Map;
 
 public class StatsCommand extends Command implements IMaintenanceCommand {
 
@@ -76,6 +78,14 @@ public class StatsCommand extends Command implements IMaintenanceCommand {
         str = str + "JDA version:                    " + JDAInfo.VERSION + "\n";
         str = str + "FredBoat version:               " + AppInfo.getAppInfo().getVersionBuild() + "\n";
         str = str + "Lavaplayer version:             " + PlayerLibrary.VERSION + "\n";
+
+        str = str + "\n----------\n\n";
+
+        str = str + "Last agent run times:\n";
+        for (Map.Entry<Class<? extends FredBoatAgent>, Long> entry : FredBoatAgent.getLastRunTimes().entrySet()) {
+            // [classname] [padded to length 32 with spaces] [date]T[time][zone]
+            str += String.format("%1$-32s%2$TFT%2$TT%2$Tz\n", entry.getKey().getSimpleName(), entry.getValue());
+        }
 
         str = str + "```";
 

--- a/FredBoat/src/main/java/fredboat/commandmeta/init/MusicCommandInitializer.java
+++ b/FredBoat/src/main/java/fredboat/commandmeta/init/MusicCommandInitializer.java
@@ -25,6 +25,7 @@
 package fredboat.commandmeta.init;
 
 import fredboat.Config;
+import fredboat.agent.FredBoatAgent;
 import fredboat.agent.VoiceChannelCleanupAgent;
 import fredboat.command.admin.*;
 import fredboat.command.maintenance.*;
@@ -125,7 +126,7 @@ public class MusicCommandInitializer {
 
         // The null check is to ensure we can run this in a test run
         if (Config.CONFIG == null || Config.CONFIG.getDistribution() != DistributionEnum.PATRON) {
-            new VoiceChannelCleanupAgent().start();
+            FredBoatAgent.start(new VoiceChannelCleanupAgent());
         } else {
             log.info("Skipped setting up the VoiceChannelCleanupAgent since we are running as PATRON distribution.");
         }


### PR DESCRIPTION
I wanted to wait with this one last, but I think it's also good to get some comments/feedback in.
So here goes.

This makes the point where agents are started unified, and cleans up the `//noinspection InfiniteLoopStatement while (true) {`, each one start a Thread, (correctly) configuring it, etc. mantra.


Caveats/notes:

- [x] This makes the starting/handling/rate-scheduling/stopping universal.
- [x] `log.info("starting xxx")` should be either 1) removed, or 2) be accompanied by `log.info("finished xxx")` or 3) be changed in logging level.
- [x] Decide on whether to use `scheduleWithFixedDelay` (which was more akin to the previous code, since there were always fixed sleep intervals) or `scheduleAtFixedRate` (which makes more sense (?) when dealing with agents/cleanup units of work).
- [x] Deal with potential `Throwable`s killing off the agents.
- [ ] Decide whether a single worker thread is enough, or if a larger threadpool or a cached threadpool is better, so 2, 3, 4 threads? Or let the cached threadpool handle it?
- [ ] Decide whether we use `AGENTS.awaitTermination()` in the shutdown, or do we just let it shutdown while we do other shutdown-y things?
- [ ] Needs a lot of eyes on the code. I have been running this code for about/over a week or two, but that's different from when it would go live for thousands of servers.
- [ ] Do not merge until all checks have been ticked, since other issues can be raised 😨. (I don't want to be *that guy who broke everything*)