### PR TITLE
Don't check if we have permission if we're already in

### DIFF
--- a/FredBoat/src/main/java/fredboat/audio/GuildPlayer.java
+++ b/FredBoat/src/main/java/fredboat/audio/GuildPlayer.java
@@ -84,6 +84,10 @@ public class GuildPlayer extends AbstractPlayer {
         if (targetChannel == null) {
             throw new MessagingException(I18n.get(getGuild()).getString("playerUserNotInChannel"));
         }
+        if (targetChannel.equals(getChannel())) {
+            // already connected to the channel
+            return;
+        }
 
         if (!targetChannel.getGuild().getSelfMember().hasPermission(targetChannel, Permission.VOICE_CONNECT)
                 && !targetChannel.getMembers().contains(getGuild().getSelfMember())) {


### PR DESCRIPTION
This helps if the bot has been moved to a channel manually (right click -> move) and the bot doesn't actually have permission to that channel.