### PR TITLE
Populate the MDC with debug information

### DIFF
--- a/FredBoat/src/main/java/fredboat/event/EventListenerBoat.java
+++ b/FredBoat/src/main/java/fredboat/event/EventListenerBoat.java
@@ -59,6 +59,7 @@ import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.core.events.message.priv.PrivateMessageReceivedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.util.concurrent.TimeUnit;
 
@@ -80,7 +81,17 @@ public class EventListenerBoat extends AbstractEventListener {
 
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
+        try (// before execution set some variables that can help with finding traces that belong to each other
+                MDC.MDCCloseable _guild = MDC.putCloseable("guild", event.getGuild().getId());
+                MDC.MDCCloseable _channel = MDC.putCloseable("channel", event.getChannel().getId());
+                MDC.MDCCloseable _invoker = MDC.putCloseable("invoker", event.getAuthor().getId());
+                ) {
 
+            doOnMessageReceived(event);
+        }
+    }
+
+    private void doOnMessageReceived(MessageReceivedEvent event) {
         if (FeatureFlags.RATE_LIMITER.isActive()) {
             if (Ratelimiter.getRatelimiter().isBlacklisted(event.getAuthor().getIdLong())) {
                 Metrics.blacklistedMessagesReceived.inc();
@@ -94,7 +105,7 @@ public class EventListenerBoat extends AbstractEventListener {
         }
 
         if (event.getAuthor().equals(event.getJDA().getSelfUser())) {
-            log.info(event.getGuild().getName() + " \t " + event.getAuthor().getName() + " \t " + event.getMessage().getRawContent());
+            log.info(event.getMessage().getRawContent());
             return;
         }
 
@@ -115,7 +126,7 @@ public class EventListenerBoat extends AbstractEventListener {
         if (context == null) {
             return;
         }
-        log.info(event.getGuild().getName() + " \t " + event.getAuthor().getName() + " \t " + event.getMessage().getRawContent());
+        log.info(event.getMessage().getRawContent());
 
         //ignore all commands in channels where we can't write, except for the help command
         if (!channel.canTalk() && !(context.command instanceof HelpCommand)) {

--- a/FredBoat/src/main/resources/logback.xml
+++ b/FredBoat/src/main/resources/logback.xml
@@ -34,7 +34,7 @@
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>
-            <pattern>[%date{HH:mm:ss}] [ %-5level] [%logger{0}] %msg%n</pattern>
+            <pattern>[%date{HH:mm:ss}] [ %-5level] [%mdc] [%logger{0}] %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -48,7 +48,7 @@
             <maxHistory>5</maxHistory>
         </rollingPolicy>
         <encoder>
-            <pattern>[%d] [ %-5level] [%thread] %logger{35}: %msg%n</pattern>
+            <pattern>[%d] [ %-5level] [%mdc] [%thread] %logger{35}: %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -62,7 +62,7 @@
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>
-            <pattern>[%date{HH:mm:ss}] [%thread] [%logger{0}] %msg%n</pattern>
+            <pattern>[%date{HH:mm:ss}] [%mdc] [%thread] [%logger{0}] %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -85,7 +85,7 @@
             <level>INFO</level>
         </filter>
         <encoder>
-            <pattern>[%date{HH:mm:ss}] [ %-5level] [%logger{0}] %msg%n</pattern>
+            <pattern>[%date{HH:mm:ss}] [ %-5level] [%mdc] [%logger{0}] %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Logback configuration is a stub.

So, during some debugging sessions it was hard to see what the trail of commands was.
This should make it easier to highlight what calls belong to each other.