### PR TITLE
Change the implementation of most counting commands

### DIFF
--- a/FredBoat/feature_flags.properties
+++ b/FredBoat/feature_flags.properties
@@ -31,4 +31,5 @@
 # example to turn a feature on (uncomment it):
 #RATE_LIMITER=false
 #CHATBOT=false
+#DATA_METHODS=false
 PERMISSIONS=false

--- a/FredBoat/pom.xml
+++ b/FredBoat/pom.xml
@@ -42,6 +42,12 @@
             <artifactId>JDA</artifactId>
             <version>3.1.1_217</version>
         </dependency>
+        <!-- because gradle doesn't make a good pom and the scope isn't set correctly -->
+        <dependency>
+            <groupId>net.sf.trove4j</groupId>
+            <artifactId>trove4j</artifactId>
+            <version>3.0.3</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>

--- a/FredBoat/src/main/java/fredboat/api/API.java
+++ b/FredBoat/src/main/java/fredboat/api/API.java
@@ -74,8 +74,8 @@ public class API {
             for (FredBoat fb : shards) {
                 JSONObject fbStats = new JSONObject();
                 fbStats.put("id", fb.getShardInfo().getShardId())
-                        .put("guilds", fb.getJda().getGuilds().size())
-                        .put("users", fb.getJda().getUsers().size())
+                        .put("guilds", fb.getGuildCount())
+                        .put("users", fb.getUserCount())
                         .put("status", fb.getJda().getStatus());
 
                 a.put(fbStats);

--- a/FredBoat/src/main/java/fredboat/command/maintenance/ShardsCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/maintenance/ShardsCommand.java
@@ -33,6 +33,7 @@ import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.MessageBuilder;
 import net.dv8tion.jda.core.entities.*;
+import net.dv8tion.jda.core.entities.impl.JDAImpl;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,8 +61,9 @@ public class ShardsCommand extends Command implements IMaintenanceCommand {
         LongOpenHashSet healthyUsers = new LongOpenHashSet(FredBoat.getExpectedUserCount());
         for (FredBoat fb : shards) {
             if (fb.getJda().getStatus() == JDA.Status.CONNECTED && !full) {
-                healthyGuilds += fb.getJda().getGuilds().size();
-                fb.getJda().getUsers().parallelStream().mapToLong(ISnowflake::getIdLong).forEach(healthyUsers::add);
+                healthyGuilds += fb.getGuildCount();
+                // casting to get the underlying map, this is safe because we only need the .size()
+                ((JDAImpl) fb.getJda()).getUserMap().size();
             } else {
                 if (borkenShards % SHARDS_PER_MESSAGE == 0) {
                     mb = new MessageBuilder()

--- a/FredBoat/src/main/java/fredboat/command/maintenance/ShardsCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/maintenance/ShardsCommand.java
@@ -29,7 +29,6 @@ import fredboat.Config;
 import fredboat.FredBoat;
 import fredboat.commandmeta.abs.Command;
 import fredboat.commandmeta.abs.IMaintenanceCommand;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.MessageBuilder;
 import net.dv8tion.jda.core.entities.*;
@@ -58,12 +57,12 @@ public class ShardsCommand extends Command implements IMaintenanceCommand {
         List<FredBoat> shards = new ArrayList<>(FredBoat.getShards());
         int borkenShards = 0;
         int healthyGuilds = 0;
-        LongOpenHashSet healthyUsers = new LongOpenHashSet(FredBoat.getExpectedUserCount());
+        int healthyUsers = 0;
         for (FredBoat fb : shards) {
             if (fb.getJda().getStatus() == JDA.Status.CONNECTED && !full) {
                 healthyGuilds += fb.getGuildCount();
                 // casting to get the underlying map, this is safe because we only need the .size()
-                ((JDAImpl) fb.getJda()).getUserMap().size();
+                healthyUsers += ((JDAImpl) fb.getJda()).getUserMap().size();
             } else {
                 if (borkenShards % SHARDS_PER_MESSAGE == 0) {
                     mb = new MessageBuilder()
@@ -88,7 +87,7 @@ public class ShardsCommand extends Command implements IMaintenanceCommand {
         if (!full) {
             channel.sendMessage("```diff\n+ "
                     + (shards.size() - borkenShards) + "/" + Config.CONFIG.getNumShards() + " shards are " + JDA.Status.CONNECTED
-                    + " -- Guilds: " + healthyGuilds + " -- Users: " + healthyUsers.size() + "\n```").queue();
+                    + " -- Guilds: " + healthyGuilds + " -- Users: " + healthyUsers + "\n```").queue();
         }
 
         //detailed shards

--- a/FredBoat/src/main/java/fredboat/command/maintenance/ShardsCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/maintenance/ShardsCommand.java
@@ -74,9 +74,9 @@ public class ShardsCommand extends Command implements IMaintenanceCommand {
                         .append(" ")
                         .append(fb.getJda().getStatus())
                         .append(" -- Guilds: ")
-                        .append(String.format("%04d", fb.getJda().getGuilds().size()))
+                        .append(String.format("%04d", fb.getGuildCount()))
                         .append(" -- Users: ")
-                        .append(fb.getJda().getUsers().size())
+                        .append(fb.getUserCount())
                         .append("\n");
                 borkenShards++;
             }

--- a/FredBoat/src/main/java/fredboat/feature/togglz/FeatureFlags.java
+++ b/FredBoat/src/main/java/fredboat/feature/togglz/FeatureFlags.java
@@ -48,7 +48,12 @@ public enum FeatureFlags implements Feature {
 
     @Label("Permissions")
     @EnabledByDefault
-    PERMISSIONS;
+    PERMISSIONS,
+
+    //using data methods that don't collect everything to new data structures
+    @Label("Streaming data methods")
+    @EnabledByDefault
+    DATA_METHODS;
 
     public boolean isActive() {
         return FeatureConfig.getTheFeatureManager().isActive(this);

--- a/FredBoat/src/main/java/fredboat/util/JDAUtil.java
+++ b/FredBoat/src/main/java/fredboat/util/JDAUtil.java
@@ -1,0 +1,146 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 Frederik Ar. Mikkelsen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+package fredboat.util;
+
+import fredboat.FredBoat;
+import fredboat.feature.togglz.FeatureFlags;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import net.dv8tion.jda.core.entities.Guild;
+import net.dv8tion.jda.core.entities.ISnowflake;
+import net.dv8tion.jda.core.entities.impl.JDAImpl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * JDA methods/hacks that had merit to put in its own class.
+ *
+ * @author Shredder121
+ */
+public class JDAUtil {
+
+
+    public static int countAllGuilds(List<FredBoat> shards) {
+        if (FeatureFlags.DATA_METHODS.isActive()) {
+            return New.countAllGuilds(shards);
+        } else {
+            return Old.countAllGuilds(shards);
+        }
+    }
+
+    public static long countAllUniqueUsers(List<FredBoat> shards, AtomicInteger biggestUserCount) {
+        if (FeatureFlags.DATA_METHODS.isActive()) {
+            return New.countAllUniqueUsers(shards, biggestUserCount);
+        } else {
+            return Old.countAllUniqueUsers(shards, biggestUserCount);
+        }
+    }
+    public static List<Guild> getAllGuilds(List<FredBoat> shards) {
+        if (FeatureFlags.DATA_METHODS.isActive()) {
+            return New.getAllGuilds(shards);
+        } else {
+            return Old.getAllGuilds(shards);
+        }
+    }
+
+
+
+    private static class New {
+
+        public static int countAllGuilds(List<FredBoat> shards) {
+            return shards.stream()
+                    // don't do this at home, we only use it for the size()
+                    .mapToInt(shard -> ((JDAImpl) shard.getJda()).getGuildMap().size())
+                    .sum();
+        }
+
+        public static long countAllUniqueUsers(List<FredBoat> shards, AtomicInteger biggestUserCount) {
+            int expected = biggestUserCount.get() > 0 ? biggestUserCount.get() : LongOpenHashSet.DEFAULT_INITIAL_SIZE;
+            LongOpenHashSet uniqueUsers = new LongOpenHashSet(expected + 100000); //add 100k for good measure
+            Collections.unmodifiableCollection(shards).forEach(
+                    // IMPLEMENTATION NOTE: READ
+                    // careful, touching the map is in not all cases safe
+                    // In this case, it just so happens to be safe, because the map is synchronized
+                    // this means however, that for the (small) duration, the map cannot be used by other threads (if there are any)
+                    shard -> ((JDAImpl) shard.getJda()).getUserMap().forEachValue(user -> {
+                        uniqueUsers.add(user.getIdLong());
+                        return true;
+                    })
+            );
+            //never shrink the user count (might happen due to not connected shards)
+            biggestUserCount.accumulateAndGet(uniqueUsers.size(), Math::max);
+            return uniqueUsers.size();
+        }
+
+        public static List<Guild> getAllGuilds(List<FredBoat> shards) {
+            ArrayList<Guild> list = new ArrayList<>();
+
+            for (FredBoat fb : shards) {
+                // addAll() does actually need to use .toArray() but 1 copy is better than 2
+                list.addAll(((JDAImpl)fb.getJda()).getGuildMap().valueCollection());
+            }
+
+            return list;
+        }
+
+        private New() {
+        }
+    }
+    private static final class Old {
+
+        public static int countAllGuilds(List<FredBoat> shards) {
+            return Collections.unmodifiableCollection(shards)
+                    .stream()
+                    .mapToInt(shard -> shard.getJda().getGuilds().size())
+                    .sum();
+        }
+
+        public static long countAllUniqueUsers(List<FredBoat> shards, AtomicInteger biggestUserCount) {
+            int expected = biggestUserCount.get() > 0 ? biggestUserCount.get() : LongOpenHashSet.DEFAULT_INITIAL_SIZE;
+            LongOpenHashSet uniqueUsers = new LongOpenHashSet(expected + 100000); //add 100k for good measure
+            Collections.unmodifiableCollection(shards).forEach(
+                    shard -> shard.getJda().getUsers().parallelStream().mapToLong(ISnowflake::getIdLong).forEach(uniqueUsers::add)
+            );
+            //never shrink the user count (might happen due to not connected shards)
+            biggestUserCount.accumulateAndGet(uniqueUsers.size(), Math::max);
+            return uniqueUsers.size();
+        }
+
+        public static List<Guild> getAllGuilds(List<FredBoat> shards) {
+            ArrayList<Guild> list = new ArrayList<>();
+
+            for (FredBoat fb : shards) {
+                list.addAll(fb.getJda().getGuilds());
+            }
+
+            return list;
+        }
+
+        private Old() {
+        }
+    }
+}


### PR DESCRIPTION
This uses the underlying map, very carefully, which in most cases are safe enough to call.

Note that the '`pom.xml`' that gradle produces has all its dependencies set to `runtime`.
So that means that trove isn't actually a transitive (compile time) dependency of JDA.
That sucks big time, but /shrug.