### PR TITLE
Make FredBoat ignore messages from other bots

### DIFF
--- a/FredBoat/src/main/java/fredboat/event/EventListenerBoat.java
+++ b/FredBoat/src/main/java/fredboat/event/EventListenerBoat.java
@@ -82,6 +82,10 @@ public class EventListenerBoat extends AbstractEventListener {
             return;
         }
 
+        if (event.getAuthor().isBot()) {
+            return;
+        }
+
         if (event.getAuthor().equals(event.getJDA().getSelfUser())) {
             log.info(event.getGuild().getName() + " \t " + event.getAuthor().getName() + " \t " + event.getMessage().getRawContent());
             return;

--- a/FredBoat/src/main/java/fredboat/event/EventListenerBoat.java
+++ b/FredBoat/src/main/java/fredboat/event/EventListenerBoat.java
@@ -82,15 +82,15 @@ public class EventListenerBoat extends AbstractEventListener {
             return;
         }
 
-        if (event.getAuthor().isBot()) {
-            return;
-        }
-
         if (event.getAuthor().equals(event.getJDA().getSelfUser())) {
             log.info(event.getGuild().getName() + " \t " + event.getAuthor().getName() + " \t " + event.getMessage().getRawContent());
             return;
         }
 
+        if (event.getAuthor().isBot()) {
+            return;
+        }
+        
         if (event.getMessage().getContent().length() < Config.CONFIG.getPrefix().length()) {
             return;
         }


### PR DESCRIPTION
Get FredBoat to ignore messages sent by other bots.

I have not tested this code. But it should be all that is needed to stop Issue #228, unless it listens elsewhere as well.