### PR TITLE
Hoist the lambda out of the loop

### DIFF
--- a/FredBoat/feature_flags.properties
+++ b/FredBoat/feature_flags.properties
@@ -31,5 +31,4 @@
 # example to turn a feature on (uncomment it):
 #RATE_LIMITER=false
 #CHATBOT=false
-#DATA_METHODS=false
 PERMISSIONS=false

--- a/FredBoat/src/main/java/fredboat/feature/togglz/FeatureFlags.java
+++ b/FredBoat/src/main/java/fredboat/feature/togglz/FeatureFlags.java
@@ -49,11 +49,7 @@ public enum FeatureFlags implements Feature {
     @Label("Permissions")
     @EnabledByDefault
     PERMISSIONS,
-
-    //using data methods that don't collect everything to new data structures
-    @Label("Streaming data methods")
-    @EnabledByDefault
-    DATA_METHODS;
+    ;
 
     public boolean isActive() {
         return FeatureConfig.getTheFeatureManager().isActive(this);


### PR DESCRIPTION
Basically, for each user the lambda had to be bootstrapped and initialized.

In the after picture, the foreach just disappeared, because it didn't do any allocations anymore.

|  before   |  after
|---------|--------
| ![Before change][before] | ![After change][after]

[before]: https://user-images.githubusercontent.com/4105066/28748449-ac3a47de-74b8-11e7-8268-522047986ed3.png
[after]: https://user-images.githubusercontent.com/4105066/28748459-feac5bb0-74b8-11e7-8443-57a17b3bda7f.png