### PR TITLE
Switch entity ids from String to long, clean up Entity Reader/Writer

### DIFF
--- a/FredBoat/src/main/java/fredboat/api/OAuthManager.java
+++ b/FredBoat/src/main/java/fredboat/api/OAuthManager.java
@@ -85,17 +85,17 @@ public class OAuthManager {
     private static UConfig saveTokenToConfig(TokenGrant token){
         User user = DiscordUtil.getUserFromBearer(FredBoat.getFirstJDA(), token.getBearer());
 
-        UConfig uconfig = EntityReader.getUConfig(user.getId());
+        UConfig uconfig = EntityReader.getEntity(user.getIdLong(), UConfig.class);
 
         uconfig = uconfig == null ? new UConfig() : uconfig;
 
         uconfig.setBearer(token.getBearer())
                 .setBearerExpiration(token.getExpirationTime())
                 .setRefresh(token.getRefresh())
-                .setUserId(user.getId());
+                .setUserId(user.getIdLong());
 
         //Save to database
-        EntityWriter.mergeUConfig(uconfig);
+        uconfig = EntityWriter.merge(uconfig);
 
         return uconfig;
     }

--- a/FredBoat/src/main/java/fredboat/audio/DebugConnectionListener.java
+++ b/FredBoat/src/main/java/fredboat/audio/DebugConnectionListener.java
@@ -38,10 +38,10 @@ class DebugConnectionListener implements ConnectionListener {
     private static final Logger log = LoggerFactory.getLogger(DebugConnectionListener.class);
 
     private ConnectionStatus oldStatus = null;
-    private final String guildId;
+    private final long guildId;
     private final FredBoat.ShardInfo shardInfo;
 
-    DebugConnectionListener(String guildId, FredBoat.ShardInfo shardInfo) {
+    DebugConnectionListener(long guildId, FredBoat.ShardInfo shardInfo) {
         this.guildId = guildId;
         this.shardInfo = shardInfo;
     }

--- a/FredBoat/src/main/java/fredboat/audio/GuildPlayer.java
+++ b/FredBoat/src/main/java/fredboat/audio/GuildPlayer.java
@@ -60,7 +60,7 @@ public class GuildPlayer extends AbstractPlayer {
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(GuildPlayer.class);
 
     private final FredBoat shard;
-    private final String guildId;
+    private final long guildId;
     public final Map<String, VideoSelection> selections = new HashMap<>();
     private String currentTCId;
 
@@ -69,7 +69,7 @@ public class GuildPlayer extends AbstractPlayer {
     @SuppressWarnings("LeakingThisInConstructor")
     public GuildPlayer(Guild guild) {
         this.shard = FredBoat.getInstance(guild.getJDA());
-        this.guildId = guild.getId();
+        this.guildId = guild.getIdLong();
 
         AudioManager manager = guild.getAudioManager();
         manager.setSendingHandler(this);
@@ -369,7 +369,7 @@ public class GuildPlayer extends AbstractPlayer {
     private boolean isTrackAnnounceEnabled() {
         boolean enabled = false;
         try {
-            GuildConfig config = EntityReader.getGuildConfig(guildId);
+            GuildConfig config = EntityReader.getEntity(guildId, GuildConfig.class);
             enabled = config.isTrackAnnounce();
         } catch (DatabaseNotReadyException ignored) {}
 

--- a/FredBoat/src/main/java/fredboat/command/moderation/ConfigCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/ConfigCommand.java
@@ -58,7 +58,7 @@ public class ConfigCommand extends Command implements IModerationCommand, IComma
     }
 
     private void printConfig(Guild guild, TextChannel channel, Member invoker, Message message, String[] args) {
-        GuildConfig gc = EntityReader.getGuildConfig(guild.getId());
+        GuildConfig gc = EntityReader.getEntity(guild.getIdLong(), GuildConfig.class);
 
         MessageBuilder mb = new MessageBuilder()
                 .append(MessageFormat.format(I18n.get(guild).getString("configNoArgs") + "\n", guild.getName()))
@@ -82,7 +82,7 @@ public class ConfigCommand extends Command implements IModerationCommand, IComma
             return;
         }
 
-        GuildConfig gc = EntityReader.getGuildConfig(guild.getId());
+        GuildConfig gc = EntityReader.getEntity(guild.getIdLong(), GuildConfig.class);
         String key = args[1];
         String val = args[2];
 
@@ -90,7 +90,7 @@ public class ConfigCommand extends Command implements IModerationCommand, IComma
             case "track_announce":
                 if (val.equalsIgnoreCase("true") | val.equalsIgnoreCase("false")) {
                     gc.setTrackAnnounce(Boolean.valueOf(val));
-                    EntityWriter.mergeGuildConfig(gc);
+                    gc = EntityWriter.merge(gc);
                     TextUtils.replyWithName(channel, invoker, "`track_announce` " + MessageFormat.format(I18n.get(guild).getString("configSetTo"), val));
                 } else {
                     channel.sendMessage(MessageFormat.format(I18n.get(guild).getString("configMustBeBoolean"), invoker.getEffectiveName())).queue();
@@ -99,7 +99,7 @@ public class ConfigCommand extends Command implements IModerationCommand, IComma
             case "auto_resume":
                 if (val.equalsIgnoreCase("true") | val.equalsIgnoreCase("false")) {
                     gc.setAutoResume(Boolean.valueOf(val));
-                    EntityWriter.mergeGuildConfig(gc);
+                    gc = EntityWriter.merge(gc);
                     TextUtils.replyWithName(channel, invoker, "`auto_resume` " + MessageFormat.format(I18n.get(guild).getString("configSetTo"), val));
                 } else {
                     channel.sendMessage(MessageFormat.format(I18n.get(guild).getString("configMustBeBoolean"), invoker.getEffectiveName())).queue();

--- a/FredBoat/src/main/java/fredboat/command/moderation/PermissionsCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/PermissionsCommand.java
@@ -40,13 +40,7 @@ import fredboat.util.ArgumentUtil;
 import fredboat.util.TextUtils;
 import net.dv8tion.jda.core.EmbedBuilder;
 import net.dv8tion.jda.core.Permission;
-import net.dv8tion.jda.core.entities.Guild;
-import net.dv8tion.jda.core.entities.IMentionable;
-import net.dv8tion.jda.core.entities.ISnowflake;
-import net.dv8tion.jda.core.entities.Member;
-import net.dv8tion.jda.core.entities.Message;
-import net.dv8tion.jda.core.entities.Role;
-import net.dv8tion.jda.core.entities.TextChannel;
+import net.dv8tion.jda.core.entities.*;
 import net.dv8tion.jda.core.utils.PermissionUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -118,7 +112,7 @@ public class PermissionsCommand extends Command implements IModerationCommand {
         List<IMentionable> search = new ArrayList<>();
         search.addAll(ArgumentUtil.fuzzyRoleSearch(guild, term));
         search.addAll(ArgumentUtil.fuzzyMemberSearch(guild, term, false));
-        GuildPermissions gp = EntityReader.getGuildPermissions(guild);
+        GuildPermissions gp = EntityReader.getEntity(guild.getIdLong(), GuildPermissions.class);
         curList.addAll(idsToMentionables(guild, gp.getFromEnum(permissionLevel)));
 
         List<IMentionable> itemsInBothLists = new ArrayList<>();
@@ -142,7 +136,7 @@ public class PermissionsCommand extends Command implements IModerationCommand {
         }
 
         gp.setFromEnum(permissionLevel, newList);
-        EntityWriter.mergeGuildPermissions(gp);
+        gp = EntityWriter.merge(gp);
 
         TextUtils.replyWithName(channel, invoker, MessageFormat.format(I18n.get(guild).getString("permsRemoved"), mentionableToName(selected), permissionLevel));
     }
@@ -153,7 +147,7 @@ public class PermissionsCommand extends Command implements IModerationCommand {
         List<IMentionable> list = new ArrayList<>();
         list.addAll(ArgumentUtil.fuzzyRoleSearch(guild, term));
         list.addAll(ArgumentUtil.fuzzyMemberSearch(guild, term, false));
-        GuildPermissions gp = EntityReader.getGuildPermissions(guild);
+        GuildPermissions gp = EntityReader.getEntity(guild.getIdLong(), GuildPermissions.class);
         list.removeAll(idsToMentionables(guild, gp.getFromEnum(permissionLevel)));
 
         IMentionable selected = ArgumentUtil.checkSingleFuzzySearchResult(list, channel, term);
@@ -162,14 +156,14 @@ public class PermissionsCommand extends Command implements IModerationCommand {
         List<String> newList = new ArrayList<>(gp.getFromEnum(permissionLevel));
         newList.add(mentionableToId(selected));
         gp.setFromEnum(permissionLevel, newList);
-        EntityWriter.mergeGuildPermissions(gp);
+        gp = EntityWriter.merge(gp);
 
         TextUtils.replyWithName(channel, invoker, MessageFormat.format(I18n.get(guild).getString("permsAdded"), mentionableToName(selected), permissionLevel));
     }
 
     public void list(Guild guild, TextChannel channel, Member invoker, Message message, String[] args) {
         EmbedBuilder builder = new EmbedBuilder();
-        GuildPermissions gp = EntityReader.getGuildPermissions(guild);
+        GuildPermissions gp = EntityReader.getEntity(guild.getIdLong(), GuildPermissions.class);
 
         List<IMentionable> mentionables = idsToMentionables(guild, gp.getFromEnum(permissionLevel));
 

--- a/FredBoat/src/main/java/fredboat/db/EntityReader.java
+++ b/FredBoat/src/main/java/fredboat/db/EntityReader.java
@@ -27,12 +27,7 @@ package fredboat.db;
 
 
 import fredboat.FredBoat;
-import fredboat.db.entity.BlacklistEntry;
-import fredboat.db.entity.GuildConfig;
-import fredboat.db.entity.GuildPermissions;
 import fredboat.db.entity.IEntity;
-import fredboat.db.entity.UConfig;
-import net.dv8tion.jda.core.entities.Guild;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,26 +39,21 @@ public class EntityReader {
 
     private static final Logger log = LoggerFactory.getLogger(EntityReader.class);
 
-    public static UConfig getUConfig(String id) {
-        return getEntity(id, UConfig.class);
-    }
-
-    public static GuildConfig getGuildConfig(String id) {
-        return getEntity(id, GuildConfig.class);
-    }
-
-    public static GuildPermissions getGuildPermissions(Guild guild) {
-        return getEntity(guild.getId(), GuildPermissions.class);
-    }
-
-    private static <E extends IEntity> E getEntity(String id, Class<E> clazz) throws DatabaseNotReadyException {
+    /**
+     * @param id    id of the entity to get
+     * @param clazz class of the entity to get
+     * @param <E>   class needs to implement IEntity
+     * @return the entity with the requested id of the requested class
+     * @throws DatabaseNotReadyException if the database is not available
+     */
+    public static <E extends IEntity> E getEntity(long id, Class<E> clazz) throws DatabaseNotReadyException {
         DatabaseManager dbManager = FredBoat.getDbManager();
         if (!dbManager.isAvailable()) {
             throw new DatabaseNotReadyException();
         }
 
         EntityManager em = dbManager.getEntityManager();
-        E config = null;
+        E config;
         try {
             config = em.find(clazz, id);
         } catch (PersistenceException e) {
@@ -77,7 +67,7 @@ public class EntityReader {
         return config;
     }
 
-    private static <E extends IEntity> E newInstance(String id, Class<E> clazz) {
+    private static <E extends IEntity> E newInstance(long id, Class<E> clazz) {
         try {
             E entity = clazz.newInstance();
             entity.setId(id);
@@ -87,18 +77,21 @@ public class EntityReader {
         }
     }
 
-    public static List<BlacklistEntry> loadBlacklist() {
+    /**
+     * @param clazz class of the entities to get
+     * @param <E>   class needs to implement IEntity
+     * @return a list of all elements of the requested class
+     */
+    public static <E extends IEntity> List<E> loadAll(Class<E> clazz) {
         DatabaseManager dbManager = FredBoat.getDbManager();
         if (!dbManager.isAvailable()) {
             throw new DatabaseNotReadyException("The database is not available currently. Please try again later.");
         }
         EntityManager em = dbManager.getEntityManager();
-        List<BlacklistEntry> result;
         try {
-            result = em.createQuery("SELECT b FROM BlacklistEntry b", BlacklistEntry.class).getResultList();
+            return em.createQuery("SELECT c FROM " + clazz.getSimpleName() + " c", clazz).getResultList();
         } finally {
             em.close();
         }
-        return result;
     }
 }

--- a/FredBoat/src/main/java/fredboat/db/EntityWriter.java
+++ b/FredBoat/src/main/java/fredboat/db/EntityWriter.java
@@ -26,11 +26,7 @@
 package fredboat.db;
 
 import fredboat.FredBoat;
-import fredboat.db.entity.BlacklistEntry;
-import fredboat.db.entity.GuildConfig;
-import fredboat.db.entity.GuildPermissions;
 import fredboat.db.entity.IEntity;
-import fredboat.db.entity.UConfig;
 import org.hibernate.exception.JDBCConnectionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,23 +37,12 @@ public class EntityWriter {
 
     private static final Logger log = LoggerFactory.getLogger(EntityWriter.class);
 
-    public static void mergeUConfig(UConfig config) {
-        merge(config);
-    }
-
-    public static void mergeGuildConfig(GuildConfig config) {
-        merge(config);
-    }
-
-    public static void mergeBlacklistEntry(BlacklistEntry ble) {
-        merge(ble);
-    }
-
-    public static void mergeGuildPermissions(GuildPermissions guildPermissions) {
-        merge(guildPermissions);
-    }
-
-    private static void merge(IEntity entity) {
+    /**
+     * @param entity entity to be merged
+     * @param <E>    entity needs to implement IEntity
+     * @return the merged entity
+     */
+    public static <E extends IEntity> E merge(E entity) {
         DatabaseManager dbManager = FredBoat.getDbManager();
         if (!dbManager.isAvailable()) {
             throw new DatabaseNotReadyException();
@@ -66,8 +51,9 @@ public class EntityWriter {
         EntityManager em = dbManager.getEntityManager();
         try {
             em.getTransaction().begin();
-            em.merge(entity);
+            E mergedEntity = em.merge(entity);
             em.getTransaction().commit();
+            return mergedEntity;
         } catch (JDBCConnectionException e) {
             log.error("Failed to merge entity {}", entity, e);
             throw new DatabaseNotReadyException(e);
@@ -76,7 +62,12 @@ public class EntityWriter {
         }
     }
 
-    public static void deleteBlacklistEntry(long id) {
+    /**
+     * @param id    primary key of the entity to be deleted
+     * @param clazz class of the entity to be deleted
+     * @param <E>   entity needs to implement IEntity
+     */
+    public static <E extends IEntity> void delete(long id, Class<E> clazz) {
         DatabaseManager dbManager = FredBoat.getDbManager();
         if (!dbManager.isAvailable()) {
             throw new DatabaseNotReadyException("The database is not available currently. Please try again later.");
@@ -84,11 +75,11 @@ public class EntityWriter {
 
         EntityManager em = dbManager.getEntityManager();
         try {
-            BlacklistEntry ble = em.find(BlacklistEntry.class, id);
+            E entity = em.find(clazz, id);
 
-            if (ble != null) {
+            if (entity != null) {
                 em.getTransaction().begin();
-                em.remove(ble);
+                em.remove(entity);
                 em.getTransaction().commit();
             }
         } finally {

--- a/FredBoat/src/main/java/fredboat/db/entity/BlacklistEntry.java
+++ b/FredBoat/src/main/java/fredboat/db/entity/BlacklistEntry.java
@@ -70,8 +70,8 @@ public class BlacklistEntry implements IEntity {
     }
 
     @Override
-    public void setId(String id) {
-        this.id = Long.valueOf(id);
+    public void setId(long id) {
+        this.id = id;
     }
 
     @Override

--- a/FredBoat/src/main/java/fredboat/db/entity/GuildConfig.java
+++ b/FredBoat/src/main/java/fredboat/db/entity/GuildConfig.java
@@ -39,7 +39,7 @@ import javax.persistence.Table;
 public class GuildConfig implements IEntity {
 
     @Id
-    private String guildId;
+    private long guildId;
 
     @Column(name = "track_announce", nullable = false)
     private boolean trackAnnounce = false;
@@ -50,19 +50,19 @@ public class GuildConfig implements IEntity {
     @Column(name = "lang", nullable = false)
     private String lang = "en_US";
 
-    public GuildConfig(String id) {
+    public GuildConfig(long id) {
         this.guildId = id;
     }
 
     @Override
-    public void setId(String id) {
+    public void setId(long id) {
         this.guildId = id;
     }
 
     public GuildConfig() {
     }
 
-    public String getGuildId() {
+    public long getGuildId() {
         return guildId;
     }
 

--- a/FredBoat/src/main/java/fredboat/db/entity/GuildPermissions.java
+++ b/FredBoat/src/main/java/fredboat/db/entity/GuildPermissions.java
@@ -44,17 +44,17 @@ public class GuildPermissions implements IEntity {
 
     // Guild ID
     @Id
-    private String id;
+    private long id;
 
     public GuildPermissions() {}
 
     @Override
-    public void setId(String id) {
+    public void setId(long id) {
         this.id = id;
 
         // Set up default permissions. Note that the @everyone role of a guild is of the same snowflake as the guild
-        this.djList = id;
-        this.userList = id;
+        this.djList = Long.toString(id);
+        this.userList = Long.toString(id);
     }
 
     @Column(name = "list_admin", nullable = false, columnDefinition = "text")

--- a/FredBoat/src/main/java/fredboat/db/entity/IEntity.java
+++ b/FredBoat/src/main/java/fredboat/db/entity/IEntity.java
@@ -33,5 +33,5 @@ package fredboat.db.entity;
  */
 public interface IEntity {
 
-    void setId(String id);
+    void setId(long id);
 }

--- a/FredBoat/src/main/java/fredboat/db/entity/UConfig.java
+++ b/FredBoat/src/main/java/fredboat/db/entity/UConfig.java
@@ -34,7 +34,7 @@ import javax.persistence.Table;
 public class UConfig implements IEntity {
 
     @Id
-    private String userId;
+    private long userId;
     private String bearer;
     private String refresh;
     private long bearerexpiration;
@@ -47,7 +47,7 @@ public class UConfig implements IEntity {
         return refresh;
     }
 
-    public String getUserId() {
+    public long getUserId() {
         return userId;
     }
 
@@ -55,12 +55,12 @@ public class UConfig implements IEntity {
         return bearerexpiration;
     }
 
-    public UConfig(String id) {
+    public UConfig(long id) {
         this.userId = id;
     }
 
     @Override
-    public void setId(String id) {
+    public void setId(long id) {
         this.userId = id;
     }
 
@@ -77,7 +77,7 @@ public class UConfig implements IEntity {
         return this;
     }
 
-    public UConfig setUserId(String userId) {
+    public UConfig setUserId(long userId) {
         this.userId = userId;
         return this;
     }

--- a/FredBoat/src/main/java/fredboat/event/EventListenerBoat.java
+++ b/FredBoat/src/main/java/fredboat/event/EventListenerBoat.java
@@ -34,6 +34,7 @@ import fredboat.commandmeta.CommandManager;
 import fredboat.commandmeta.CommandRegistry;
 import fredboat.commandmeta.abs.Command;
 import fredboat.db.EntityReader;
+import fredboat.db.entity.GuildConfig;
 import fredboat.feature.I18n;
 import fredboat.feature.togglz.FeatureFlags;
 import fredboat.util.Tuple2;
@@ -222,7 +223,7 @@ public class EventListenerBoat extends AbstractEventListener {
                 && player.getPlayingTrack() != null
                 && event.getChannelJoined().getMembers().contains(event.getGuild().getSelfMember())
                 && player.getHumanUsersInVC().size() == 1
-                && EntityReader.getGuildConfig(event.getGuild().getId()).isAutoResume()
+                && EntityReader.getEntity(event.getGuild().getIdLong(), GuildConfig.class).isAutoResume()
                 ) {
             player.getActiveTextChannel().sendMessage(I18n.get(event.getGuild()).getString("eventAutoResumed")).queue();
             player.setPause(false);

--- a/FredBoat/src/main/java/fredboat/feature/I18n.java
+++ b/FredBoat/src/main/java/fredboat/feature/I18n.java
@@ -90,7 +90,7 @@ public class I18n {
         GuildConfig config;
 
         try {
-            config = EntityReader.getGuildConfig(guild.getId());
+            config = EntityReader.getEntity(guild.getIdLong(), GuildConfig.class);
         } catch (DatabaseNotReadyException e) {
             //don't log spam the full exceptions or logs
             return DEFAULT;
@@ -106,9 +106,9 @@ public class I18n {
         if (!LANGS.containsKey(lang))
             throw new LanguageNotSupportedException("Language not found");
 
-        GuildConfig config = EntityReader.getGuildConfig(guild.getId());
+        GuildConfig config = EntityReader.getEntity(guild.getIdLong(), GuildConfig.class);
         config.setLang(lang);
-        EntityWriter.mergeGuildConfig(config);
+        config = EntityWriter.merge(config);
     }
 
     public static class FredBoatLocale {

--- a/FredBoat/src/main/java/fredboat/perms/PermsUtil.java
+++ b/FredBoat/src/main/java/fredboat/perms/PermsUtil.java
@@ -56,7 +56,7 @@ public class PermsUtil {
             return PermissionUtil.checkPermission(member, Permission.MESSAGE_MANAGE) ? PermissionLevel.DJ : PermissionLevel.USER;
         }
 
-        GuildPermissions gp = EntityReader.getGuildPermissions(member.getGuild());
+        GuildPermissions gp = EntityReader.getEntity(member.getGuild().getIdLong(), GuildPermissions.class);
 
         if (checkList(gp.getAdminList(), member)) return PermissionLevel.ADMIN;
         if (checkList(gp.getDjList(), member)) return PermissionLevel.DJ;

--- a/FredBoat/src/main/java/fredboat/util/ratelimit/Blacklist.java
+++ b/FredBoat/src/main/java/fredboat/util/ratelimit/Blacklist.java
@@ -70,7 +70,7 @@ public class Blacklist {
     public Blacklist(Set<Long> userWhiteList, long rateLimitHitsBeforeBlacklist) {
         this.blacklist = new Long2ObjectOpenHashMap<>();
         //load blacklist from database
-        for (BlacklistEntry ble : EntityReader.loadBlacklist()) {
+        for (BlacklistEntry ble : EntityReader.loadAll(BlacklistEntry.class)) {
             blacklist.put(ble.id, ble);
         }
 
@@ -134,7 +134,7 @@ public class Blacklist {
             }
             //persist it
             //if this turns up to be a performance bottleneck, have an agent run that persists the blacklist occasionally
-            EntityWriter.mergeBlacklistEntry(blEntry);
+            blacklist.put(blEntry.getId(), EntityWriter.merge(blEntry));
             return blacklistingLength;
         }
     }
@@ -159,7 +159,7 @@ public class Blacklist {
      */
     public synchronized void liftBlacklist(long id) {
         blacklist.remove(id);
-        EntityWriter.deleteBlacklistEntry(id);
+        EntityWriter.delete(id, BlacklistEntry.class);
     }
 
     /**


### PR DESCRIPTION
This will need some column alterations to be done when deploying.
Here are the necessary SQL queries:
ALTER TABLE public.guild_config ALTER COLUMN guildid TYPE bigint USING guildid::bigint
ALTER TABLE public.user_config ALTER COLUMN userid TYPE bigint USING userid::bigint
ALTER TABLE public.guild_permissions ALTER COLUMN id TYPE bigint USING id::bigint


The discordant methods in the Entity classes and using String ids when they are actually long snowflakes have been grinding my gears _long_ enough. I want to change that before it gets worse (it does with persistent tracklists and whatever the orchestrator will be).

The thing to keep in mind when applying this is to update the patron bot (and main) too.