### PR TITLE
Allow BOT_ADMINs to use "Destroy" regardless of permissions

### DIFF
--- a/FredBoat/src/main/java/fredboat/command/music/control/DestroyCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/DestroyCommand.java
@@ -44,7 +44,7 @@ public class DestroyCommand extends Command implements IMusicCommand, ICommandRe
     @Override
     public void onInvoke(Guild guild, TextChannel channel, Member invoker, Message message, String[] args) {
         if(invoker.hasPermission(channel, Permission.MESSAGE_MANAGE)
-                || PermsUtil.isUserBotOwner(invoker.getUser())) {
+                || PermsUtil.checkPerms(PermissionLevel.BOT_ADMIN, invoker)) {
             PlayerRegistry.destroyPlayer(guild);
             TextUtils.replyWithName(channel, invoker, I18n.get(guild).getString("destroySucc"));
         } else {

--- a/FredBoat/src/main/java/fredboat/command/music/control/DestroyCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/DestroyCommand.java
@@ -44,7 +44,7 @@ public class DestroyCommand extends Command implements IMusicCommand, ICommandRe
     @Override
     public void onInvoke(Guild guild, TextChannel channel, Member invoker, Message message, String[] args) {
         if(invoker.hasPermission(channel, Permission.MESSAGE_MANAGE)
-                || PermsUtil.checkPerms(PermissionLevel.BOT_ADMIN, invoker)) {
+                || PermsUtil.checkPerms(PermissionLevel.ADMIN, invoker)) {
             PlayerRegistry.destroyPlayer(guild);
             TextUtils.replyWithName(channel, invoker, I18n.get(guild).getString("destroySucc"));
         } else {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13600006/29541617-8af1451c-86d5-11e7-8a1f-821bbe8ad2cb.png)
![image](https://user-images.githubusercontent.com/13600006/29541620-8e403142-86d5-11e7-9aba-db9aa4c55f9f.png)
I left the "destroyDenied" message untouched as it does not really affect anyone but is Bot Admins.   
This fixes #231