### PR TITLE
Advertise patreon on leave setting

### DIFF
--- a/FredBoat/src/main/java/fredboat/feature/togglz/FeatureFlags.java
+++ b/FredBoat/src/main/java/fredboat/feature/togglz/FeatureFlags.java
@@ -55,6 +55,9 @@ public enum FeatureFlags implements Feature {
 
     @Label("Force soundcloud search instead of youtube")
     FORCE_SOUNDCLOUD_SEARCH,
+
+    @Label("Advertise donation page on leave")
+    ADVERTISE_DONATION_ON_LEAVE,
     ;
 
     public boolean isActive() {


### PR DESCRIPTION
This adds a feature flag that allows FredBoat to advertise FredBoat Patron when ;;leave is called.

This only works under the following conditions:
- The feature is enabled (disabled by default, no selfhosting hassle)
- The player has existed for at least an hour
- The message has not been posted the last 2 hours for that guild/player

TODO: Translations

Thoughts?