### PR TITLE
Cache search results + fallback to Youtube API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,4 +134,4 @@ target/
 gc-*.log
 *dbconf.yaml
 /config.yaml
-fredboat\.db
+*fredboat.db

--- a/FredBoat/.gitignore
+++ b/FredBoat/.gitignore
@@ -4,4 +4,3 @@
 /credentials_test.json
 /credentials.json.old
 *.ppk
-fredboat.db

--- a/FredBoat/src/main/java/fredboat/Config.java
+++ b/FredBoat/src/main/java/fredboat/Config.java
@@ -320,6 +320,14 @@ public class Config {
         return distribution;
     }
 
+    public boolean isPatronDistribution() {
+        return distribution == DistributionEnum.PATRON;
+    }
+
+    public boolean isDevDistribution() {
+        return distribution == DistributionEnum.DEVELOPMENT;
+    }
+
     public String getBotToken() {
         return botToken;
     }

--- a/FredBoat/src/main/java/fredboat/audio/source/SpotifyPlaylistSourceManager.java
+++ b/FredBoat/src/main/java/fredboat/audio/source/SpotifyPlaylistSourceManager.java
@@ -102,7 +102,7 @@ public class SpotifyPlaylistSourceManager implements AudioSourceManager, Playlis
         List<CompletableFuture<AudioTrack>> taskList = new ArrayList<>();
         for (final String s : trackListSearchTerms) {
             //remove all punctuation
-            final String query = s.replaceAll("[.,/#!$%\\^&*;:{}=\\-_`~()]", "");
+            final String query = s.replaceAll(SearchUtil.PUNCTUATION_REGEX, "");
 
             CompletableFuture<AudioTrack> f = CompletableFuture.supplyAsync(() -> searchSingleTrack(query), FredBoat.executor);
             taskList.add(f);

--- a/FredBoat/src/main/java/fredboat/audio/source/SpotifyPlaylistSourceManager.java
+++ b/FredBoat/src/main/java/fredboat/audio/source/SpotifyPlaylistSourceManager.java
@@ -27,21 +27,29 @@ package fredboat.audio.source;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
-import com.sedmelluq.discord.lavaplayer.track.*;
-import fredboat.FredBoat;
+import com.sedmelluq.discord.lavaplayer.track.AudioItem;
+import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist;
+import com.sedmelluq.discord.lavaplayer.track.AudioReference;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
+import com.sedmelluq.discord.lavaplayer.track.BasicAudioPlaylist;
 import fredboat.audio.queue.PlaylistInfo;
 import fredboat.util.rest.SearchUtil;
 import fredboat.util.rest.SpotifyAPIWrapper;
-import org.json.JSONException;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -54,11 +62,20 @@ import java.util.regex.Pattern;
  */
 public class SpotifyPlaylistSourceManager implements AudioSourceManager, PlaylistImporter {
 
-    private static final org.slf4j.Logger log = LoggerFactory.getLogger(SpotifyPlaylistSourceManager.class);
+    public static long CACHE_DURATION = TimeUnit.DAYS.toMillis(7);// 1 week;
+
+    private static final Logger log = LoggerFactory.getLogger(SpotifyPlaylistSourceManager.class);
 
     //https://regex101.com/r/AEWyxi/3
     private static final Pattern PLAYLIST_PATTERN = Pattern.compile("https?://.*\\.spotify\\.com/user/(.*)/playlist/([^?/\\s]*)");
 
+    //Take care when deciding on upping the core pool size: The threads may hog database connections
+    // (for selfhosters running on the SQLite db) when loading an uncached playlist.
+    // Upping the threads will also fire search requests more aggressively against Youtube which is probably better avoided.
+    private static final ScheduledExecutorService loader = Executors.newScheduledThreadPool(1);
+
+    private static final List<SearchUtil.SearchProvider> searchProviders
+            = Arrays.asList(SearchUtil.SearchProvider.YOUTUBE, SearchUtil.SearchProvider.SOUNDCLOUD);
 
     @Override
     public String getSourceName() {
@@ -104,7 +121,7 @@ public class SpotifyPlaylistSourceManager implements AudioSourceManager, Playlis
             //remove all punctuation
             final String query = s.replaceAll(SearchUtil.PUNCTUATION_REGEX, "");
 
-            CompletableFuture<AudioTrack> f = CompletableFuture.supplyAsync(() -> searchSingleTrack(query), FredBoat.executor);
+            CompletableFuture<AudioTrack> f = CompletableFuture.supplyAsync(() -> searchSingleTrack(query), loader);
             taskList.add(f);
         }
 
@@ -116,7 +133,10 @@ public class SpotifyPlaylistSourceManager implements AudioSourceManager, Playlis
                     continue; //skip the track if we couldn't find it
                 }
                 trackList.add(audioItem);
-            } catch (InterruptedException | ExecutionException e) {
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (ExecutionException ignored) {
                 //this is fine, loop will go for the next item
             }
         }
@@ -133,45 +153,26 @@ public class SpotifyPlaylistSourceManager implements AudioSourceManager, Playlis
      * @return An AudioTrack likely corresponding to the query term or null.
      */
     private AudioTrack searchSingleTrack(final String query) {
-        boolean gotYoutubeResult = true;
-        AudioPlaylist list = null;
         try {
-            list = SearchUtil.searchForTracks(SearchUtil.SearchProvider.YOUTUBE, query, 60000);
-            if (list == null || list.getTracks().size() == 0) {
-                gotYoutubeResult = false;
+            AudioPlaylist list = SearchUtil.searchForTracks(query, CACHE_DURATION, 60000, searchProviders);
+            //didn't find anything
+            if (list == null || list.getTracks().isEmpty()) {
+                return null;
             }
-        } catch (final JSONException e) {
-            log.debug("YouTube search exception", e);
-            gotYoutubeResult = false;
-        }
 
-        //got a result from youtube? return it
-        if (gotYoutubeResult)
+            //pick topmost result, and hope it's what the user wants to listen to
+            //having users pick tracks like they can do for individual searches would be ridiculous for playlists with
+            //dozens of tracks. youtube search is probably good enough for this
+            //
+            //testcase:   Rammstein playlists; high quality Rammstein vids are really rare on Youtube.
+            //            https://open.spotify.com/user/11174036433/playlist/0ePRMvD3Dn3zG31A8y64xX
+            //result:     lots of low quality (covers, pitched up/down, etc) tracks loaded.
+            //conclusion: there's room for improvement to this whole method
             return list.getTracks().get(0);
-
-
-        //continue looking for the track on SoundCloud
-        try {
-            list = SearchUtil.searchForTracks(SearchUtil.SearchProvider.SOUNDCLOUD, query, 60000);
-        } catch (final JSONException e) {
-            log.debug("SoundCloud search exception", e);
-        }
-
-        //didn't find anything, or youtube & soundcloud not available
-        if (list == null || list.getTracks().size() == 0) {
+        } catch (SearchUtil.SearchingException e) {
+            //youtube & soundcloud not available
             return null;
         }
-
-        //pick topmost result, and hope it's what the user wants to listen to
-        //having users pick tracks like they can do for individual searches would be ridiculous for playlists with
-        //dozens of tracks. youtube search is probably good enough for this
-        //
-        //testcase:   Rammstein playlists; high quality Rammstein vids are really rare on Youtube.
-        //            https://open.spotify.com/user/11174036433/playlist/0ePRMvD3Dn3zG31A8y64xX
-        //result:     lots of low quality (covers, pitched up/down, etc) tracks loaded.
-        //conclusion: there's room for improvement to this whole method
-        return list.getTracks().get(0);
-
     }
 
     @Override

--- a/FredBoat/src/main/java/fredboat/audio/source/SpotifyPlaylistSourceManager.java
+++ b/FredBoat/src/main/java/fredboat/audio/source/SpotifyPlaylistSourceManager.java
@@ -74,7 +74,7 @@ public class SpotifyPlaylistSourceManager implements AudioSourceManager, Playlis
     //Take care when deciding on upping the core pool size: The threads may hog database connections
     // (for selfhosters running on the SQLite db) when loading an uncached playlist.
     // Upping the threads will also fire search requests more aggressively against Youtube which is probably better avoided.
-    private static final ScheduledExecutorService loader = Executors.newScheduledThreadPool(1);
+    public static ScheduledExecutorService loader = Executors.newScheduledThreadPool(1);
 
     private static final List<SearchUtil.SearchProvider> searchProviders
             = Arrays.asList(SearchUtil.SearchProvider.YOUTUBE, SearchUtil.SearchProvider.SOUNDCLOUD);

--- a/FredBoat/src/main/java/fredboat/audio/source/SpotifyPlaylistSourceManager.java
+++ b/FredBoat/src/main/java/fredboat/audio/source/SpotifyPlaylistSourceManager.java
@@ -58,6 +58,8 @@ import java.util.regex.Pattern;
  * <p>
  * Loads playlists from Spotify playlist links.
  *
+ * todo bulk load the songs from the search cache (remote db connections are slow when loading one by one)
+ *
  * @author napster
  */
 public class SpotifyPlaylistSourceManager implements AudioSourceManager, PlaylistImporter {

--- a/FredBoat/src/main/java/fredboat/command/music/control/PlayCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/PlayCommand.java
@@ -145,7 +145,7 @@ public class PlayCommand extends Command implements IMusicCommand, ICommandRestr
         String query = m.group(1);
         
         //Now remove all punctuation
-        query = query.replaceAll("[.,/#!$%\\^&*;:{}=\\-_`~()]", "");
+        query = query.replaceAll(SearchUtil.PUNCTUATION_REGEX, "");
 
         String finalQuery = query;
         channel.sendMessage(I18n.get(guild).getString("playSearching").replace("{q}", query)).queue(outMsg -> {

--- a/FredBoat/src/main/java/fredboat/command/music/info/NowplayingCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/info/NowplayingCommand.java
@@ -120,7 +120,7 @@ public class NowplayingCommand extends Command implements IMusicCommand {
 
         MessageEmbed embed = eb.setColor(new Color(205, 32, 31))
                 .setThumbnail("https://i.ytimg.com/vi/" + at.getIdentifier() + "/hqdefault.jpg")
-                .setAuthor(yv.getCannelTitle(), yv.getChannelUrl(), yv.getChannelThumbUrl())
+                .setAuthor(yv.getChannelTitle(), yv.getChannelUrl(), yv.getChannelThumbUrl())
                 .setFooter(channel.getJDA().getSelfUser().getName(), channel.getJDA().getSelfUser().getAvatarUrl())
                 .build();
         channel.sendMessage(embed).queue();

--- a/FredBoat/src/main/java/fredboat/commandmeta/init/MusicCommandInitializer.java
+++ b/FredBoat/src/main/java/fredboat/commandmeta/init/MusicCommandInitializer.java
@@ -61,7 +61,8 @@ public class MusicCommandInitializer {
         CommandRegistry.registerCommand("commands", new CommandsCommand(), "comms", "cmds");
         
         /* Control */
-        CommandRegistry.registerCommand("play", new PlayCommand(SearchUtil.SearchProvider.YOUTUBE), "yt", "youtube");
+        CommandRegistry.registerCommand("play", new PlayCommand(SearchUtil.SearchProvider.YOUTUBE, SearchUtil.SearchProvider.SOUNDCLOUD));
+        CommandRegistry.registerCommand("yt", new PlayCommand(SearchUtil.SearchProvider.YOUTUBE), "youtube");
         CommandRegistry.registerCommand("sc", new PlayCommand(SearchUtil.SearchProvider.SOUNDCLOUD), "soundcloud");
         CommandRegistry.registerCommand("skip", new SkipCommand(), "sk");
         CommandRegistry.registerCommand("join", new JoinCommand(), "summon", "jn");

--- a/FredBoat/src/main/java/fredboat/db/DatabaseManager.java
+++ b/FredBoat/src/main/java/fredboat/db/DatabaseManager.java
@@ -103,6 +103,11 @@ public class DatabaseManager {
             //caution: only add new columns, don't remove or alter old ones, otherwise manual db table migration needed
             properties.put("hibernate.hbm2ddl.auto", "update");
 
+            //disable autocommit, it is not recommended for our usecases.
+            //see https://vladmihalcea.com/2017/05/17/why-you-should-always-use-hibernate-connection-provider_disables_autocommit-for-resource-local-jpa-transactions/
+            properties.put("hibernate.connection.autocommit", "false");
+            properties.put("hibernate.connection.provider_disables_autocommit", "true");
+
             properties.put("hibernate.hikari.maximumPoolSize", Integer.toString(poolSize));
 
             //how long to wait for a connection becoming available, also the timeout when a DB fails

--- a/FredBoat/src/main/java/fredboat/db/DatabaseNotReadyException.java
+++ b/FredBoat/src/main/java/fredboat/db/DatabaseNotReadyException.java
@@ -39,11 +39,11 @@ public class DatabaseNotReadyException extends MessagingException {
         super(str);
     }
 
-    DatabaseNotReadyException(Throwable cause) {
+    public DatabaseNotReadyException(Throwable cause) {
         super(DEFAULT_MESSAGE, cause);
     }
 
-    DatabaseNotReadyException() {
+    public DatabaseNotReadyException() {
         super(DEFAULT_MESSAGE);
     }
 }

--- a/FredBoat/src/main/java/fredboat/db/entity/SearchResult.java
+++ b/FredBoat/src/main/java/fredboat/db/entity/SearchResult.java
@@ -35,6 +35,7 @@ import fredboat.FredBoat;
 import fredboat.db.DatabaseManager;
 import fredboat.db.DatabaseNotReadyException;
 import fredboat.util.rest.SearchUtil;
+import org.apache.commons.lang3.SerializationUtils;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.slf4j.Logger;
@@ -79,7 +80,7 @@ public class SearchResult {
 
     @Lob
     @Column(name = "search_result")
-    private SerializableAudioPlaylist encodedSearchResult;
+    private byte[] serializedSearchResult;
 
     //for JPA
     public SearchResult() {
@@ -89,7 +90,7 @@ public class SearchResult {
                         AudioPlaylist searchResult) {
         this.searchResultId = new SearchResultId(provider, searchTerm);
         this.timestamp = System.currentTimeMillis();
-        this.encodedSearchResult = new SerializableAudioPlaylist(playerManager, searchResult);
+        this.serializedSearchResult = SerializationUtils.serialize(new SerializableAudioPlaylist(playerManager, searchResult));
     }
 
     /**
@@ -180,11 +181,12 @@ public class SearchResult {
     }
 
     public AudioPlaylist getSearchResult(AudioPlayerManager playerManager) {
-        return encodedSearchResult.decode(playerManager);
+        SerializableAudioPlaylist sap = SerializationUtils.deserialize(serializedSearchResult);
+        return sap.decode(playerManager);
     }
 
     public void setSearchResult(AudioPlayerManager playerManager, AudioPlaylist searchResult) {
-        this.encodedSearchResult = new SerializableAudioPlaylist(playerManager, searchResult);
+        this.serializedSearchResult = SerializationUtils.serialize(new SerializableAudioPlaylist(playerManager, searchResult));
     }
 
     /**

--- a/FredBoat/src/main/java/fredboat/db/entity/SearchResult.java
+++ b/FredBoat/src/main/java/fredboat/db/entity/SearchResult.java
@@ -1,0 +1,334 @@
+/*
+ *
+ * MIT License
+ *
+ * Copyright (c) 2017 Frederik Ar. Mikkelsen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package fredboat.db.entity;
+
+import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
+import com.sedmelluq.discord.lavaplayer.tools.io.MessageInput;
+import com.sedmelluq.discord.lavaplayer.tools.io.MessageOutput;
+import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist;
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import com.sedmelluq.discord.lavaplayer.track.BasicAudioPlaylist;
+import fredboat.FredBoat;
+import fredboat.db.DatabaseManager;
+import fredboat.db.DatabaseNotReadyException;
+import fredboat.util.rest.SearchUtil;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.Id;
+import javax.persistence.Lob;
+import javax.persistence.PersistenceException;
+import javax.persistence.Table;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Created by napster on 27.08.17.
+ * <p>
+ * Caches a search result
+ */
+@Entity
+@Table(name = "search_results")
+//todo does this need to be added to ehcache.xml?
+@Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "search_results")
+//todo after introducing the db refactoring in the persistent tracklists PR:
+//- refactor load() and save() as calls to EntityReader and EntityWriter
+//- make this class implement IEntity<SearchResultId>
+public class SearchResult {
+
+    private static final Logger log = LoggerFactory.getLogger(SearchResult.class);
+
+    @Id
+    private SearchResultId searchResultId;
+
+    @Column(name = "timestamp")
+    private long timestamp;
+
+    @Lob
+    @Column(name = "search_result")
+    private SerializableAudioPlaylist encodedSearchResult;
+
+    //for JPA
+    public SearchResult() {
+    }
+
+    public SearchResult(AudioPlayerManager playerManager, SearchUtil.SearchProvider provider, String searchTerm,
+                        AudioPlaylist searchResult) {
+        this.searchResultId = new SearchResultId(provider, searchTerm);
+        this.timestamp = System.currentTimeMillis();
+        this.encodedSearchResult = new SerializableAudioPlaylist(playerManager, searchResult);
+    }
+
+    /**
+     * @param playerManager the PlayerManager to perform encoding and decoding with
+     * @param provider      the search provider that shall be used for this search
+     * @param searchTerm    the query to search for
+     * @param maxAgeMillis  the maximum age of the cached search result; provide a negative value for eternal cache
+     * @return the cached search result; may return null for a non-existing or outdated search
+     */
+    public static AudioPlaylist load(AudioPlayerManager playerManager, SearchUtil.SearchProvider provider,
+                                     String searchTerm, long maxAgeMillis) {
+        DatabaseManager dbManager = FredBoat.getDbManager();
+        if (!dbManager.isAvailable()) {
+            throw new DatabaseNotReadyException();
+        }
+
+        EntityManager em = dbManager.getEntityManager();
+        SearchResult sr;
+        SearchResultId sId = new SearchResultId(provider, searchTerm);
+        try {
+            sr = em.find(SearchResult.class, sId);
+        } catch (PersistenceException e) {
+            log.error("Unexpected error while trying to look up a search result for provider {} and search term {}", provider.name(), searchTerm, e);
+            throw new DatabaseNotReadyException(e);
+        } finally {
+            em.close();
+        }
+
+        if (sr != null && (maxAgeMillis < 0 || System.currentTimeMillis() < sr.timestamp + maxAgeMillis)) {
+            return sr.getSearchResult(playerManager);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Persist a search in the database.
+     *
+     * @return the merged SearchResult object
+     */
+    public SearchResult save() {
+        DatabaseManager dbManager = FredBoat.getDbManager();
+        if (!dbManager.isAvailable()) {
+            throw new DatabaseNotReadyException();
+        }
+
+        EntityManager em = dbManager.getEntityManager();
+        try {
+            em.getTransaction().begin();
+            SearchResult managed = em.merge(this);
+            em.getTransaction().commit();
+            return managed;
+        } catch (PersistenceException e) {
+            log.error("Unexpected error while saving a search result for provider {} and search term {}",
+                    searchResultId.provider, searchResultId.searchTerm, e);
+            throw new DatabaseNotReadyException(e);
+        } finally {
+            em.close();
+        }
+    }
+
+    public SearchResultId getId() {
+        return searchResultId;
+    }
+
+    public SearchUtil.SearchProvider getProvider() {
+        return searchResultId.getProvider();
+    }
+
+    public void setProvider(SearchUtil.SearchProvider provider) {
+        searchResultId.provider = provider.name();
+    }
+
+    public String getSearchTerm() {
+        return searchResultId.searchTerm;
+    }
+
+    public void setSearchTerm(String searchTerm) {
+        this.searchResultId.searchTerm = searchTerm;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public AudioPlaylist getSearchResult(AudioPlayerManager playerManager) {
+        return encodedSearchResult.decode(playerManager);
+    }
+
+    public void setSearchResult(AudioPlayerManager playerManager, AudioPlaylist searchResult) {
+        this.encodedSearchResult = new SerializableAudioPlaylist(playerManager, searchResult);
+    }
+
+    /**
+     * Composite primary key for SearchResults
+     */
+    @Embeddable
+    static class SearchResultId implements Serializable {
+
+        private static final long serialVersionUID = 8969973651938173208L;
+
+        @Column(name = "provider", nullable = false)
+        private String provider;
+
+        @Column(name = "search_term", nullable = false)
+        private String searchTerm;
+
+        //for jpa
+        public SearchResultId() {
+        }
+
+        public SearchResultId(SearchUtil.SearchProvider provider, String searchTerm) {
+            this.provider = provider.name();
+            this.searchTerm = searchTerm;
+        }
+
+        public SearchUtil.SearchProvider getProvider() {
+            return SearchUtil.SearchProvider.valueOf(provider);
+        }
+
+        public void setProvider(SearchUtil.SearchProvider provider) {
+            this.provider = provider.name();
+        }
+
+        public String getSearchTerm() {
+            return searchTerm;
+        }
+
+        public void setSearchTerm(String searchTerm) {
+            this.searchTerm = searchTerm;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(provider, searchTerm);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof SearchResultId)) return false;
+            SearchResultId other = (SearchResultId) o;
+            return provider.equals(other.provider) && searchTerm.equals(other.searchTerm);
+        }
+    }
+
+
+    private static class SerializableAudioPlaylist implements Serializable {
+        private static final long serialVersionUID = -6823555858689776338L;
+
+        private String name;
+        private byte[][] tracks;
+        private byte[] selectedTrack;
+        private boolean isSearchResult;
+
+        //required for deserialization
+        SerializableAudioPlaylist() {
+        }
+
+        public SerializableAudioPlaylist(AudioPlayerManager playerManager, AudioPlaylist audioPlaylist) {
+            this.name = audioPlaylist.getName();
+            this.tracks = encodeTracks(playerManager, audioPlaylist.getTracks());
+            this.selectedTrack = encodeTrack(playerManager, audioPlaylist.getSelectedTrack());
+            this.isSearchResult = audioPlaylist.isSearchResult();
+        }
+
+        public AudioPlaylist decode(AudioPlayerManager playerManager) {
+            return new BasicAudioPlaylist(name,
+                    decodeTracks(playerManager, tracks),
+                    decodeTrack(playerManager, selectedTrack),
+                    isSearchResult);
+        }
+
+        private static byte[][] encodeTracks(AudioPlayerManager playerManager, List<AudioTrack> tracks) {
+            if (tracks == null) {
+                return new byte[0][];
+            }
+
+            byte[][] encoded = new byte[tracks.size()][];
+            int skipped = 0;
+            for (int i = 0; i < tracks.size(); i++) {
+                encoded[i] = encodeTrack(playerManager, tracks.get(i));
+                if (encoded[i] == null) {
+                    skipped++;
+                }
+            }
+
+            byte[][] result = new byte[tracks.size() - skipped][];
+            int i = 0;
+            for (byte[] encodedTrack : encoded) {
+                if (encodedTrack != null) {
+                    result[i] = encodedTrack;
+                    i++;
+                }
+            }
+
+            return result;
+        }
+
+        //may return null if the encoding fails or the input is null
+        private static byte[] encodeTrack(AudioPlayerManager playerManager, AudioTrack track) {
+            if (track == null) {
+                return null;
+            }
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                playerManager.encodeTrack(new MessageOutput(baos), track);
+                return baos.toByteArray();
+            } catch (IOException ignored) {
+                return null;
+            }
+        }
+
+        private static List<AudioTrack> decodeTracks(AudioPlayerManager playerManager, byte[][] input) {
+            List<AudioTrack> result = new ArrayList<>();
+            if (input == null) return result;
+
+            for (byte[] track : input) {
+                AudioTrack decoded = decodeTrack(playerManager, track);
+                if (decoded != null) {
+                    result.add(decoded);
+                }
+            }
+            return result;
+        }
+
+        //may return null if the decoding fails or the input is null
+        private static AudioTrack decodeTrack(AudioPlayerManager playerManager, byte[] input) {
+            if (input == null) return null;
+            ByteArrayInputStream bais = new ByteArrayInputStream(input);
+            try {
+                return playerManager.decodeTrack(new MessageInput(bais)).decodedTrack;
+            } catch (IOException e) {
+                return null;
+            }
+        }
+    }
+}

--- a/FredBoat/src/main/java/fredboat/db/entity/SearchResult.java
+++ b/FredBoat/src/main/java/fredboat/db/entity/SearchResult.java
@@ -100,7 +100,7 @@ public class SearchResult {
      * @return the cached search result; may return null for a non-existing or outdated search
      */
     public static AudioPlaylist load(AudioPlayerManager playerManager, SearchUtil.SearchProvider provider,
-                                     String searchTerm, long maxAgeMillis) {
+                                     String searchTerm, long maxAgeMillis) throws DatabaseNotReadyException {
         DatabaseManager dbManager = FredBoat.getDbManager();
         if (!dbManager.isAvailable()) {
             throw new DatabaseNotReadyException();

--- a/FredBoat/src/main/java/fredboat/db/entity/SearchResult.java
+++ b/FredBoat/src/main/java/fredboat/db/entity/SearchResult.java
@@ -63,7 +63,6 @@ import java.util.Objects;
  */
 @Entity
 @Table(name = "search_results")
-//todo does this need to be added to ehcache.xml?
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE, region = "search_results")
 //todo after introducing the db refactoring in the persistent tracklists PR:
 //- refactor load() and save() as calls to EntityReader and EntityWriter

--- a/FredBoat/src/main/java/fredboat/util/rest/SearchUtil.java
+++ b/FredBoat/src/main/java/fredboat/util/rest/SearchUtil.java
@@ -50,6 +50,8 @@ public class SearchUtil {
     private static final int DEFAULT_TIMEOUT = 3000;
     private static final long CACHE_MAX_AGE = TimeUnit.HOURS.toMillis(24); //24 hours
 
+    public static final String PUNCTUATION_REGEX = "[.,/#!$%^&*;:{}=\\-_`~()\"\']";
+
     private static AudioPlayerManager initPlayerManager() {
         DefaultAudioPlayerManager manager = new DefaultAudioPlayerManager();
         YoutubeAudioSourceManager youtubeAudioSourceManager = new YoutubeAudioSourceManager();

--- a/FredBoat/src/main/java/fredboat/util/rest/SearchUtil.java
+++ b/FredBoat/src/main/java/fredboat/util/rest/SearchUtil.java
@@ -33,6 +33,10 @@ import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioSourceManager
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import com.sedmelluq.discord.lavaplayer.track.BasicAudioPlaylist;
+import fredboat.Config;
+import fredboat.FredBoat;
+import fredboat.db.DatabaseNotReadyException;
 import fredboat.db.entity.SearchResult;
 import fredboat.feature.togglz.FeatureFlags;
 import org.apache.http.client.config.CookieSpecs;
@@ -40,17 +44,20 @@ import org.apache.http.client.config.RequestConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 public class SearchUtil {
+
+    public static final long DEFAULT_CACHE_MAX_AGE = TimeUnit.HOURS.toMillis(24); //24 hours
+    public static final String PUNCTUATION_REGEX = "[.,/#!$%^&*;:{}=\\-_`~()\"\']";
 
     private static final Logger log = LoggerFactory.getLogger(SearchUtil.class);
 
     private static final AudioPlayerManager PLAYER_MANAGER = initPlayerManager();
     private static final int DEFAULT_TIMEOUT = 3000;
-    private static final long CACHE_MAX_AGE = TimeUnit.HOURS.toMillis(24); //24 hours
-
-    public static final String PUNCTUATION_REGEX = "[.,/#!$%^&*;:{}=\\-_`~()\"\']";
 
     private static AudioPlayerManager initPlayerManager() {
         DefaultAudioPlayerManager manager = new DefaultAudioPlayerManager();
@@ -63,12 +70,86 @@ public class SearchUtil {
         return manager;
     }
 
-    public static AudioPlaylist searchForTracks(SearchProvider provider, String query) {
-        return searchForTracks(provider, query, DEFAULT_TIMEOUT);
+    public static AudioPlaylist searchForTracks(String query, List<SearchProvider> providers) throws SearchingException {
+        return searchForTracks(query, DEFAULT_CACHE_MAX_AGE, DEFAULT_TIMEOUT, providers);
     }
 
-    public static AudioPlaylist searchForTracks(SearchProvider provider, String query, int timeout) {
-        return new SearchResultHandler().searchSync(provider, query, timeout);
+    /**
+     * @param query         The search term
+     * @param cacheMaxAge   Age of acceptable results from cache. See {@link fredboat.db.entity.SearchResult#load} for details.
+     * @param timeoutMillis How long to wait for each lavaplayer search to answer
+     * @param providers     Providers that shall be used for the search. They will be used in the order they are provided, the
+     *                      result of the first successful one will be returned
+     * @return The result of the search, or an empty list.
+     * @throws SearchingException If none of the search providers could give us a result, and there was at least one SearchingException thrown by them
+     */
+    public static AudioPlaylist searchForTracks(String query, long cacheMaxAge, int timeoutMillis, List<SearchProvider> providers)
+            throws SearchingException {
+
+        List<SearchProvider> provs = new ArrayList<>();
+        if (providers == null || providers.size() == 0) {
+            log.warn("No search provider provided, defaulting to youtube -> soundcloud.");
+            provs.add(SearchProvider.YOUTUBE);
+            provs.add(SearchProvider.SOUNDCLOUD);
+        } else {
+            provs.addAll(providers);
+        }
+
+        SearchingException exception = null;
+
+        for (SearchProvider provider : provs) {
+            //1. cache
+            AudioPlaylist cacheResult = fromCache(provider, query, cacheMaxAge);
+            if (cacheResult != null && !cacheResult.getTracks().isEmpty()) {
+                log.debug("Loaded search result {} {} from cache", provider, query);
+                return cacheResult;
+            }
+
+            //2. lavaplayer
+            try {
+                AudioPlaylist lavaplayerResult = new SearchResultHandler().searchSync(provider, query, timeoutMillis);
+                if (!lavaplayerResult.getTracks().isEmpty()) {
+                    log.debug("Loaded search result {} {} from lavaplayer", provider, query);
+                    // got a search result? cache and return it
+                    FredBoat.executor.submit(() -> new SearchResult(PLAYER_MANAGER, provider, query, lavaplayerResult).save());
+                    return lavaplayerResult;
+                }
+            } catch (SearchingException e) {
+                exception = e;
+            }
+
+            //3. optional: youtube api
+            if (provider == SearchProvider.YOUTUBE &&
+                    (Config.CONFIG.isPatronDistribution() || Config.CONFIG.isDevDistribution())) {
+                try {
+                    AudioPlaylist youtubeApiResult = YoutubeAPI.search(query, 5, PLAYER_MANAGER.source(YoutubeAudioSourceManager.class));
+                    if (!youtubeApiResult.getTracks().isEmpty()) {
+                        log.debug("Loaded search result {} {} from Youtube API", provider, query);
+                        // got a search result? cache and return it
+                        FredBoat.executor.submit(() -> new SearchResult(PLAYER_MANAGER, provider, query, youtubeApiResult).save());
+                        return youtubeApiResult;
+                    }
+                } catch (SearchingException e) {
+                    exception = e;
+                }
+            }
+        }
+
+        //did we run into searching exceptions that made us end up here?
+        if (exception != null) {
+            throw exception;
+        }
+        //no result with any of the search providers
+        return new BasicAudioPlaylist("Search result for: " + query, Collections.emptyList(), null, true);
+    }
+
+    private static AudioPlaylist fromCache(SearchProvider provider, String query, long cacheMaxAge) {
+        try {
+            return SearchResult.load(PLAYER_MANAGER, provider, query, cacheMaxAge);
+        } catch (DatabaseNotReadyException ignored) {
+            log.warn("Could not retrieve cached search result from database.");
+            return null;
+        }
     }
 
     public enum SearchProvider {
@@ -86,45 +167,57 @@ public class SearchUtil {
         }
     }
 
+    public static class SearchingException extends Exception {
+        private static final long serialVersionUID = -1020150337258395420L;
+
+        public SearchingException(String message) {
+            super(message);
+        }
+
+        public SearchingException(String message, Exception cause) {
+            super(message, cause);
+        }
+    }
+
     static class SearchResultHandler implements AudioLoadResultHandler {
 
-        Throwable throwable;
+        Exception exception;
         AudioPlaylist result;
         final Object toBeNotified = new Object();
 
-        AudioPlaylist searchSync(SearchProvider provider, String query, int timeout) {
+        /**
+         * @return The result of the search (which may be empty but not null).
+         */
+        AudioPlaylist searchSync(SearchProvider provider, String query, int timeoutMillis) throws SearchingException {
             if (FeatureFlags.FORCE_SOUNDCLOUD_SEARCH.isActive()) {
                 provider = SearchProvider.SOUNDCLOUD;
-            }
-
-            result = SearchResult.load(PLAYER_MANAGER, provider, query, CACHE_MAX_AGE);
-            if (result != null) {
-                log.debug("Loaded search result {} {} from cache", provider, query);
-                return result;
             }
 
             try {
                 synchronized (toBeNotified) {
                     PLAYER_MANAGER.loadItem(provider.getPrefix() + query, this);
-                    toBeNotified.wait(timeout);
+                    toBeNotified.wait(timeoutMillis);
                 }
             } catch (InterruptedException e) {
-                throw new RuntimeException("Was interrupted while searching", e);
+                Thread.currentThread().interrupt();
             }
 
-            if(throwable != null) {
-                throw new RuntimeException("Failed to search!", throwable);
+            if (exception != null) {
+                String message = String.format("Failed to search provider %s for query %s with exception %s.",
+                        provider, query, exception.getMessage());
+                throw new SearchingException(message, exception);
             }
 
-            if (result != null) {
-                new SearchResult(PLAYER_MANAGER, provider, query, result).save();
+            if (result == null) {
+                throw new SearchingException(String.format("Result from provider %s for query %s is unexpectedly null", provider, query));
             }
+
             return result;
         }
 
         @Override
         public void trackLoaded(AudioTrack audioTrack) {
-            throwable = new UnsupportedOperationException("Can't load a single track when we are expecting a playlist!");
+            exception = new UnsupportedOperationException("Can't load a single track when we are expecting a playlist!");
             synchronized (toBeNotified) {
                 toBeNotified.notify();
             }
@@ -148,7 +241,7 @@ public class SearchUtil {
 
         @Override
         public void loadFailed(FriendlyException e) {
-            throwable = e;
+            exception = e;
             synchronized (toBeNotified) {
                 toBeNotified.notify();
             }

--- a/FredBoat/src/main/java/fredboat/util/rest/YoutubeVideo.java
+++ b/FredBoat/src/main/java/fredboat/util/rest/YoutubeVideo.java
@@ -45,6 +45,7 @@ public class YoutubeVideo {
     String description = null;
     String channelId = null;
     String channelTitle = null;
+    boolean isStream = false;
 
     public String getId() {
         return id;
@@ -66,8 +67,17 @@ public class YoutubeVideo {
         return channelId;
     }
 
-    public String getCannelTitle() {
+    public String getChannelTitle() {
         return channelTitle;
+    }
+
+    public boolean isStream() {
+        return isStream;
+    }
+
+    public long getDurationInMillis() {
+        return isStream ? Long.MAX_VALUE :
+                ((getDurationHours() * 60 + getDurationMinutes()) * 60 + getDurationSeconds()) * 1000;
     }
 
     public int getDurationHours() {

--- a/FredBoat/src/main/resources/ehcache.xml
+++ b/FredBoat/src/main/resources/ehcache.xml
@@ -60,6 +60,13 @@
             overflowToDisk="true"
     />
 
+    <cache
+            name="search_results"
+            maxElementsInMemory="1000000"
+            eternal="true"
+            overflowToDisk="true"
+    />
+
     <cache name="org.hibernate.cache.internal.StandardQueryCache"
            maxEntriesLocalHeap="5" eternal="false" timeToLiveSeconds="120">
         <persistence strategy="localTempSwap" />


### PR DESCRIPTION
This will cache all searches happening through SearchUtil for 24 hours, reducing our calls to Youtube (and Soundcloud).

Not only does it reduce our calls to Youtube, it speeds up the whole execution of the command (subjective impression here).

Part of the solution of #259