### PR TITLE
Use the permission system for config command

### DIFF
--- a/FredBoat/src/main/java/fredboat/command/moderation/ConfigCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/ConfigCommand.java
@@ -70,9 +70,7 @@ public class ConfigCommand extends Command implements IModerationCommand, IComma
     }
 
     private void setConfig(Guild guild, TextChannel channel, Member invoker, Message message, String[] args) {
-        if (!invoker.hasPermission(Permission.ADMINISTRATOR)
-                && !PermsUtil.isUserBotOwner(invoker.getUser())){
-            channel.sendMessage(MessageFormat.format(I18n.get(guild).getString("configNotAdmin"), invoker.getEffectiveName())).queue();
+        if (PermsUtil.checkPermsWithFeedback(PermissionLevel.ADMIN, invoker, channel)){
             return;
         }
 


### PR DESCRIPTION
Another one of those pebble prs.
I don't know if this is intended that config command is limited to Admins of a server only but by moving this to the perm system it's basically the same with the exception that Bot admins can also change these settings  
EDIT:
should we remove the now not used string from i13n ?