### PR TITLE
Fix perm commands search terms & Add db file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ target/
 gc-*.log
 *dbconf.yaml
 /config.yaml
+fredboat\.db

--- a/FredBoat/src/main/java/fredboat/util/ArgumentUtil.java
+++ b/FredBoat/src/main/java/fredboat/util/ArgumentUtil.java
@@ -137,7 +137,8 @@ public class ArgumentUtil {
 
     public static String getSearchTerm(Message message, String[] args, int argsToStrip) {
         String raw = message.getRawContent();
-        return raw.substring(raw.indexOf(args[argsToStrip])).trim();
+        raw = raw.substring(args[0].length());
+        return raw.substring(raw.indexOf(args[argsToStrip]));
     }
 
 }


### PR DESCRIPTION
fixes #256 

I don't know if this fix is fine or if you want this fixed differently but it works  

I also added the db file to `.gitignore` since I didn't see any reason why it should not be ignored and when you run the bot with IntelliJ it generates the db file and git always wants to add it. If this is not wanted just give word and I revert the change.
also yappr (yet another pebble pr)