### PR TITLE
Make unsafe lazy initialization safe again

### DIFF
--- a/FredBoat/src/main/java/fredboat/commandmeta/CommandManager.java
+++ b/FredBoat/src/main/java/fredboat/commandmeta/CommandManager.java
@@ -58,7 +58,6 @@ public class CommandManager {
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(CommandManager.class);
 
     public static final AtomicInteger commandsExecuted = new AtomicInteger(0);
-    private static PatronageChecker patronageChecker = null;
 
     public static void prefixCalled(Command invoked, Guild guild, TextChannel channel, Member invoker, Message message) {
         String[] args = commandToArguments(message.getRawContent());
@@ -79,9 +78,7 @@ public class CommandManager {
         }
 
         if (FeatureFlags.PATRON_VALIDATION.isActive()) {
-            if (patronageChecker == null) patronageChecker = new PatronageChecker();
-
-            PatronageChecker.Status status = patronageChecker.getStatus(guild);
+            PatronageChecker.Status status = PatronageCheckerHolder.instance.getStatus(guild);
             if (!status.isValid()) {
                 String msg = "Access denied. This bot can only be used if invited from <https://patron.fredboat.com/> "
                         + "by someone who currently has a valid pledge on Patreon.\n**Denial reason:** " + status.getReason() + "\n\n";
@@ -195,5 +192,10 @@ public class CommandManager {
         }
 
         return a;
+    }
+
+    //holder class pattern for the checker
+    private static class PatronageCheckerHolder {
+        private static final PatronageChecker instance = new PatronageChecker();
     }
 }

--- a/FredBoat/src/main/java/fredboat/feature/togglz/FeatureConfig.java
+++ b/FredBoat/src/main/java/fredboat/feature/togglz/FeatureConfig.java
@@ -40,26 +40,26 @@ import java.io.File;
  */
 public class FeatureConfig implements FeatureManagerProvider {
 
-    private static FeatureManager featureManager;
-
     @Override
     public FeatureManager getFeatureManager() {
         return getTheFeatureManager();
     }
 
-    public static FeatureManager getTheFeatureManager() {
-        if (featureManager == null) {
-            featureManager = new FeatureManagerBuilder()
-                    .featureEnum(FeatureFlags.class)
-                    .stateRepository(new FileBasedStateRepository(new File("./feature_flags.properties")))
-                    .userProvider(new NoOpUserProvider())
-                    .build();
-        }
-        return featureManager;
+    static FeatureManager getTheFeatureManager() {
+        return FeatureManagerHolder.instance;
     }
 
     @Override
     public int priority() {
         return 0;
+    }
+
+    //holder class pattern
+    private static class FeatureManagerHolder {
+        private static final FeatureManager instance = new FeatureManagerBuilder()
+                .featureEnum(FeatureFlags.class)
+                .stateRepository(new FileBasedStateRepository(new File("./feature_flags.properties")))
+                .userProvider(new NoOpUserProvider())
+                .build();
     }
 }

--- a/FredBoat/src/main/java/fredboat/util/ratelimit/Ratelimiter.java
+++ b/FredBoat/src/main/java/fredboat/util/ratelimit/Ratelimiter.java
@@ -52,14 +52,23 @@ public class Ratelimiter {
 
     private static final int RATE_LIMIT_HITS_BEFORE_BLACKLIST = 10;
 
-    public static Ratelimiter getRatelimiter() {
-        return RateLimiterHolder.instance;
-    }
-
-    //holder class pattern
     //one ratelimiter for all running shards
-    private static class RateLimiterHolder {
-        private static final Ratelimiter instance = new Ratelimiter();
+    private static volatile Ratelimiter ratelimiterSingleton;
+
+    public static Ratelimiter getRatelimiter() {
+        Ratelimiter singleton = ratelimiterSingleton;
+        if (singleton == null) {
+            //we can't use the holder class pattern.
+            //we have to use double-checked locking,
+            //since we need to be able to retry the creation.
+            synchronized (Ratelimiter.class) {
+                singleton = ratelimiterSingleton;
+                if (singleton == null) {
+                    ratelimiterSingleton = singleton = new Ratelimiter();
+                }
+            }
+        }
+        return singleton;
     }
 
     private final List<Ratelimit> ratelimits;

--- a/FredBoat/src/main/java/fredboat/util/ratelimit/Ratelimiter.java
+++ b/FredBoat/src/main/java/fredboat/util/ratelimit/Ratelimiter.java
@@ -52,17 +52,15 @@ public class Ratelimiter {
 
     private static final int RATE_LIMIT_HITS_BEFORE_BLACKLIST = 10;
 
-
-    //one ratelimiter for all running shards
-    private static Ratelimiter ratelimiterSingleton;
-
     public static Ratelimiter getRatelimiter() {
-        if (ratelimiterSingleton == null)
-            ratelimiterSingleton = new Ratelimiter();
-
-        return ratelimiterSingleton;
+        return RateLimiterHolder.instance;
     }
 
+    //holder class pattern
+    //one ratelimiter for all running shards
+    private static class RateLimiterHolder {
+        private static final Ratelimiter instance = new Ratelimiter();
+    }
 
     private final List<Ratelimit> ratelimits;
     private Blacklist autoBlacklist = null;

--- a/FredBoat/src/main/java/fredboat/util/rest/SpotifyAPIWrapper.java
+++ b/FredBoat/src/main/java/fredboat/util/rest/SpotifyAPIWrapper.java
@@ -58,7 +58,6 @@ public class SpotifyAPIWrapper {
     private static final String URL_SPOTIFY_AUTHENTICATION_HOST = "https://accounts.spotify.com";
 
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(SpotifyAPIWrapper.class);
-    private static volatile SpotifyAPIWrapper SPOTIFYAPIWRAPPER;
 
     /**
      * This should be the only way to grab a handle on this class.
@@ -67,10 +66,12 @@ public class SpotifyAPIWrapper {
      * @return the singleton of the Spotify API
      */
     public static SpotifyAPIWrapper getApi() {
-        if (SPOTIFYAPIWRAPPER == null) {
-            SPOTIFYAPIWRAPPER = new SpotifyAPIWrapper();
-        }
-        return SPOTIFYAPIWRAPPER;
+        return SpotifyAPIWrapperHolder.instance;
+    }
+
+    //holder class pattern
+    private static class SpotifyAPIWrapperHolder {
+        private static final SpotifyAPIWrapper instance = new SpotifyAPIWrapper();
     }
 
     private volatile long accessTokenExpires = 0;


### PR DESCRIPTION
This uses the holder class pattern, so the JVM can do the locking when initializing for us.