### PR TITLE
UserInfoCommand will now also check bot users.

### DIFF
--- a/FredBoat/src/main/java/fredboat/command/util/UserInfoCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/util/UserInfoCommand.java
@@ -56,7 +56,7 @@ public class UserInfoCommand extends Command implements IUtilCommand {
         if(args.length == 1) {
             target = invoker;
         } else {
-            target = ArgumentUtil.checkSingleFuzzyMemberSearchResult(channel,args[1]);
+            target = ArgumentUtil.checkSingleFuzzyMemberSearchResult(channel,args[1],true);
         }
         if (target == null) return;
         for(Guild g: FredBoat.getAllGuilds()) {

--- a/FredBoat/src/main/java/fredboat/util/ArgumentUtil.java
+++ b/FredBoat/src/main/java/fredboat/util/ArgumentUtil.java
@@ -75,9 +75,12 @@ public class ArgumentUtil {
         return list;
     }
 
-
     public static Member checkSingleFuzzyMemberSearchResult(TextChannel tc, String term) {
-        List<Member> list = fuzzyMemberSearch(tc.getGuild(), term, false);
+        return checkSingleFuzzyMemberSearchResult(tc, term, false);
+    }
+
+    public static Member checkSingleFuzzyMemberSearchResult(TextChannel tc, String term, boolean includeBots) {
+        List<Member> list = fuzzyMemberSearch(tc.getGuild(), term, includeBots);
 
         switch (list.size()) {
             case 0:


### PR DESCRIPTION
Fix for issue #279. This only applies to `;;userinfo` and `;;muserinfo` commands for now.

If other commands need this, it should be fairly easy to add.