### PR TITLE
Check FBH hardcoeded setting b4 perm check

### DIFF
--- a/FredBoat/src/main/java/fredboat/commandmeta/CommandManager.java
+++ b/FredBoat/src/main/java/fredboat/commandmeta/CommandManager.java
@@ -106,17 +106,6 @@ public class CommandManager {
             return;
         }
 
-        if (invoked instanceof ICommandRestricted) {
-            //Check if invoker actually has perms
-            PermissionLevel minPerms = ((ICommandRestricted) invoked).getMinimumPerms();
-            PermissionLevel actual = PermsUtil.getPerms(invoker);
-
-            if(actual.getLevel() < minPerms.getLevel()) {
-                TextUtils.replyWithName(channel, invoker, MessageFormat.format(I18n.get(guild).getString("cmdPermsTooLow"), minPerms, actual));
-                return;
-            }
-        }
-
         //Hardcode music commands in FredBoatHangout. Blacklist any channel that isn't #general or #staff, but whitelist Frederikam
         if (invoked instanceof IMusicCommand
                 && guild.getId().equals(BotConstants.FREDBOAT_HANGOUT_ID)
@@ -134,6 +123,17 @@ public class CommandManager {
                     );
                 });
 
+                return;
+            }
+        }
+
+        if (invoked instanceof ICommandRestricted) {
+            //Check if invoker actually has perms
+            PermissionLevel minPerms = ((ICommandRestricted) invoked).getMinimumPerms();
+            PermissionLevel actual = PermsUtil.getPerms(invoker);
+
+            if(actual.getLevel() < minPerms.getLevel()) {
+                TextUtils.replyWithName(channel, invoker, MessageFormat.format(I18n.get(guild).getString("cmdPermsTooLow"), minPerms, actual));
                 return;
             }
         }


### PR DESCRIPTION
I didn't test it but this is just one check b4 another so I'm 99.99999% sure nothing can blow up because of this. it's simply doing the fbh hard-coded channel/owner check b4 the perm check as we have a special message which deletes itself while the perm check doesn't