### PR TITLE
Handle Insufficent permission exceptions in messaging

### DIFF
--- a/FredBoat/src/main/java/fredboat/command/music/control/SelectCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/SelectCommand.java
@@ -41,7 +41,6 @@ import fredboat.perms.PermissionLevel;
 import fredboat.util.TextUtils;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.Member;
-import net.dv8tion.jda.core.exceptions.PermissionException;
 import org.apache.commons.lang3.StringUtils;
 
 import java.text.MessageFormat;
@@ -78,14 +77,10 @@ public class SelectCommand extends Command implements IMusicCommand, ICommandRes
                     AudioTrack selected = selection.getChoices().get(i - 1);
                     player.selections.remove(invoker.getUser().getId());
                     String msg = MessageFormat.format(I18n.get(context, "selectSuccess"), i, selected.getInfo().title, TextUtils.formatTime(selected.getInfo().length));
-                    CentralMessaging.editMessageById(context.channel, selection.getOutMsgId(), CentralMessaging.from(msg));
+                    CentralMessaging.editMessage(context.channel, selection.getOutMsgId(), CentralMessaging.from(msg));
                     player.queue(new AudioTrackContext(selected, invoker));
                     player.setPause(false);
-                    try {
-                        context.deleteMessage();
-                    } catch (PermissionException ignored) {
-
-                    }
+                    context.deleteMessage();
                 }
             } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
                 context.reply(MessageFormat.format(I18n.get(context, "selectInterval"), selection.getChoices().size()));

--- a/FredBoat/src/main/java/fredboat/command/music/info/NowplayingCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/info/NowplayingCommand.java
@@ -37,7 +37,6 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import fredboat.audio.player.GuildPlayer;
 import fredboat.audio.player.PlayerRegistry;
 import fredboat.audio.queue.AudioTrackContext;
-import fredboat.commandmeta.MessagingException;
 import fredboat.commandmeta.abs.Command;
 import fredboat.commandmeta.abs.CommandContext;
 import fredboat.commandmeta.abs.IMusicCommand;
@@ -48,7 +47,6 @@ import fredboat.util.TextUtils;
 import fredboat.util.rest.YoutubeAPI;
 import fredboat.util.rest.YoutubeVideo;
 import net.dv8tion.jda.core.EmbedBuilder;
-import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.Guild;
 import org.json.JSONObject;
 import org.json.XML;
@@ -66,12 +64,6 @@ public class NowplayingCommand extends Command implements IMusicCommand {
         ResourceBundle i18n = I18n.get(context.guild);
 
         if (player.isPlaying()) {
-
-            // we are about to send an embed, but can we even do that? //todo move error handling to central messaging
-            if (!context.guild.getSelfMember().hasPermission(context.channel, Permission.MESSAGE_EMBED_LINKS)) {
-                throw new MessagingException(i18n.getString("permissionMissingBot") + " "
-                        + i18n.getString("permissionEmbedLinks"));
-            }
 
             AudioTrackContext atc = player.getPlayingTrack();
             AudioTrack at = atc.getTrack();

--- a/FredBoat/src/main/java/fredboat/messaging/CentralMessaging.java
+++ b/FredBoat/src/main/java/fredboat/messaging/CentralMessaging.java
@@ -33,11 +33,14 @@ import net.dv8tion.jda.core.entities.Message;
 import net.dv8tion.jda.core.entities.MessageChannel;
 import net.dv8tion.jda.core.entities.MessageEmbed;
 import net.dv8tion.jda.core.entities.TextChannel;
+import net.dv8tion.jda.core.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.core.requests.Request;
 import net.dv8tion.jda.core.requests.Response;
 import net.dv8tion.jda.core.requests.RestAction;
 import net.dv8tion.jda.core.requests.Route;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -51,6 +54,8 @@ import java.util.function.Consumer;
  * Everything related to sending things out from FredBoat
  */
 public class CentralMessaging {
+
+    private static final Logger log = LoggerFactory.getLogger(CentralMessaging.class);
 
 
     // ********************************************************************************
@@ -316,7 +321,8 @@ public class CentralMessaging {
     public static MessageFuture editMessage(@Nonnull Message oldMessage, @Nonnull Message newMessage,
                                             @Nullable Consumer<Message> onSuccess, @Nullable Consumer<Throwable> onFail) {
         return editMessage0(
-                oldMessage,
+                oldMessage.getChannel(),
+                oldMessage.getIdLong(),
                 newMessage,
                 onSuccess,
                 onFail
@@ -325,7 +331,8 @@ public class CentralMessaging {
 
     public static MessageFuture editMessage(@Nonnull Message oldMessage, @Nonnull Message newMessage) {
         return editMessage0(
-                oldMessage,
+                oldMessage.getChannel(),
+                oldMessage.getIdLong(),
                 newMessage,
                 null,
                 null
@@ -334,15 +341,44 @@ public class CentralMessaging {
 
     public static MessageFuture editMessage(@Nonnull Message oldMessage, @Nonnull String newContent) {
         return editMessage0(
-                oldMessage,
+                oldMessage.getChannel(),
+                oldMessage.getIdLong(),
                 from(newContent),
                 null,
                 null
         );
     }
 
-    public static void editMessageById(MessageChannel channel, long oldMessageId, Message newMessage) {
-        channel.editMessageById(oldMessageId, newMessage).queue();
+
+    public static MessageFuture editMessage(@Nonnull MessageChannel channel, long oldMessageId, @Nonnull Message newMessage,
+                                            @Nullable Consumer<Message> onSuccess, @Nullable Consumer<Throwable> onFail) {
+        return editMessage0(
+                channel,
+                oldMessageId,
+                newMessage,
+                onSuccess,
+                onFail
+        );
+    }
+
+    public static MessageFuture editMessage(@Nonnull MessageChannel channel, long oldMessageId, @Nonnull Message newMessage) {
+        return editMessage0(
+                channel,
+                oldMessageId,
+                newMessage,
+                null,
+                null
+        );
+    }
+
+    public static MessageFuture editMessage(@Nonnull MessageChannel channel, long oldMessageId, @Nonnull String newContent) {
+        return editMessage0(
+                channel,
+                oldMessageId,
+                from(newContent),
+                null,
+                null
+        );
     }
 
     // ********************************************************************************
@@ -350,7 +386,12 @@ public class CentralMessaging {
     // ********************************************************************************
 
     public static void sendTyping(MessageChannel channel) {
-        channel.sendTyping().queue();
+        try {
+            channel.sendTyping().queue();
+        } catch (InsufficientPermissionException e) {
+            sendMessage(channel,
+                    "I am missing the following permission in this channel: `" + e.getPermission().getName() + "`"); //todo i18n?
+        }
     }
 
     //messages must all be from the same channel
@@ -358,19 +399,29 @@ public class CentralMessaging {
         if (!messages.isEmpty()) {
             MessageChannel channel = messages.iterator().next().getChannel();
             if (channel instanceof TextChannel) {
-                ((TextChannel) channel).deleteMessages(messages).queue();
+                try {
+                    ((TextChannel) channel).deleteMessages(messages).queue();
+                } catch (InsufficientPermissionException e) {
+                    sendMessage(channel,
+                            "I am missing the following permission in this channel: `" + e.getPermission().getName() + "`"); //todo i18n?
+                }
             } else {
-                messages.forEach(m -> channel.deleteMessageById(m.getIdLong()).queue());
+                messages.forEach(m -> deleteMessageById(channel, m.getIdLong()));
             }
         }
     }
 
     public static void deleteMessage(Message message) {
-        message.delete().queue();
+        deleteMessageById(message.getChannel(), message.getIdLong());
     }
 
     public static void deleteMessageById(MessageChannel channel, long messageId) {
-        channel.deleteMessageById(messageId).queue();
+        try {
+            channel.deleteMessageById(messageId).queue();
+        } catch (InsufficientPermissionException e) {
+            sendMessage(channel,
+                    "I am missing the following permission in this channel: `" + e.getPermission().getName() + "`"); //todo i18n?
+        }
     }
 
     public static EmbedBuilder addFooter(EmbedBuilder eb, Member author) {
@@ -406,7 +457,12 @@ public class CentralMessaging {
             }
         };
 
-        channel.sendMessage(message).queue(successWrapper, failureWrapper);
+        try {
+            channel.sendMessage(message).queue(successWrapper, failureWrapper);
+        } catch (InsufficientPermissionException e) {
+            failureWrapper.accept(e);
+            log.warn("Could not send message to channel {} due to missing permission {}", channel.getIdLong(), e.getPermission().getName(), e);
+        }
         return result;
     }
 
@@ -434,15 +490,21 @@ public class CentralMessaging {
             }
         };
 
-        channel.sendFile(file, message).queue(successWrapper, failureWrapper);
+        try {
+            channel.sendFile(file, message).queue(successWrapper, failureWrapper);
+        } catch (InsufficientPermissionException e) {
+            failureWrapper.accept(e);
+            sendMessage(channel,
+                    "I am missing the following permission in this channel: `" + e.getPermission().getName() + "`"); //todo i18n?
+        }
         return result;
     }
 
     //class internal editing method
-    private static MessageFuture editMessage0(@Nonnull Message oldMessage, @Nonnull Message newMessage,
+    private static MessageFuture editMessage0(@Nonnull MessageChannel channel, long oldMessageId, @Nonnull Message newMessage,
                                               @Nullable Consumer<Message> onSuccess, @Nullable Consumer<Throwable> onFail) {
-        if (oldMessage == null) {
-            throw new IllegalArgumentException("Old message is null");
+        if (channel == null) {
+            throw new IllegalArgumentException("Channel is null");
         }
         if (newMessage == null) {
             throw new IllegalArgumentException("New message is null");
@@ -462,7 +524,13 @@ public class CentralMessaging {
             }
         };
 
-        oldMessage.editMessage(newMessage).queue(successWrapper, failureWrapper);
+        try {
+            channel.editMessageById(oldMessageId, newMessage).queue(successWrapper, failureWrapper);
+        } catch (InsufficientPermissionException e) {
+            failureWrapper.accept(e);
+            sendMessage(channel,
+                    "I am missing the following permission in this channel: `" + e.getPermission().getName() + "`"); //todo i18n?
+        }
         return result;
     }
 


### PR DESCRIPTION
~~If we encounter missing permissions during anything messaging related, we will send a message saying which permission we are missing (for example embeds, or attaching files, etc).~~

~~If we encounter missing permissions while sending a message, we will just log that to prevent a loop. (this shouldn't be happening in the first place since we don't accept commands from channels that don't allow us to write messages).~~

~~Need feedback from @Frederikam whether a) this is an acceptable flow of things and b) whether i18n is needed, and if needed whether it can be postponed (which I would prefer; a commit doing all those missing i18n todos will happen in the near future anyways).~~

Implements the behaviour of the NowplayingCommand (telling the user when there are missing permissions to display embeds) in all messaging related methods for all potentially missing permissions.