### PR TITLE
Use thread safe collection classes

### DIFF
--- a/FredBoat/src/main/java/fredboat/FredBoat.java
+++ b/FredBoat/src/main/java/fredboat/FredBoat.java
@@ -68,6 +68,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -78,7 +79,7 @@ public abstract class FredBoat {
 
     static final int SHARD_CREATION_SLEEP_INTERVAL = 5500;
 
-    private static final ArrayList<FredBoat> shards = new ArrayList<>();
+    private static final List<FredBoat> shards = new CopyOnWriteArrayList<>();
     public static final long START_TIME = System.currentTimeMillis();
     public static final int UNKNOWN_SHUTDOWN_CODE = -991023;
     public static int shutdownCode = UNKNOWN_SHUTDOWN_CODE;//Used when specifying the intended code for shutdown hooks

--- a/FredBoat/src/main/java/fredboat/audio/player/PlayerRegistry.java
+++ b/FredBoat/src/main/java/fredboat/audio/player/PlayerRegistry.java
@@ -31,12 +31,13 @@ import net.dv8tion.jda.core.entities.Guild;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class PlayerRegistry {
 
-    private static final HashMap<String, GuildPlayer> REGISTRY = new HashMap<>();
+    private static final Map<String, GuildPlayer> REGISTRY = new ConcurrentHashMap<>();
     public static final float DEFAULT_VOLUME = 1f;
 
     public static void put(String k, GuildPlayer v) {
@@ -82,7 +83,7 @@ public class PlayerRegistry {
         return REGISTRY.remove(k);
     }
 
-    public static HashMap<String, GuildPlayer> getRegistry() {
+    public static Map<String, GuildPlayer> getRegistry() {
         return REGISTRY;
     }
 

--- a/FredBoat/src/main/java/fredboat/audio/queue/MusicPersistenceHandler.java
+++ b/FredBoat/src/main/java/fredboat/audio/queue/MusicPersistenceHandler.java
@@ -54,7 +54,7 @@ import java.nio.charset.Charset;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.Map;
 
 public class MusicPersistenceHandler {
 
@@ -68,7 +68,7 @@ public class MusicPersistenceHandler {
         if (!dir.exists()) {
             dir.mkdir();
         }
-        HashMap<String, GuildPlayer> reg = PlayerRegistry.getRegistry();
+        Map<String, GuildPlayer> reg = PlayerRegistry.getRegistry();
 
         boolean isUpdate = code == ExitCodes.EXIT_CODE_UPDATE;
         boolean isRestart = code == ExitCodes.EXIT_CODE_RESTART;


### PR DESCRIPTION
So, in Sentry there were still some ConcurrentModificationExceptions that reminded me to fix this.

Cleanup of wrapping some return values in `synchronized/unmodifiable` counterparts still needed.