### PR TITLE
Add Blacklist Command

### DIFF
--- a/FredBoat/src/main/java/fredboat/command/moderation/BlacklistCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/BlacklistCommand.java
@@ -1,0 +1,214 @@
+package fredboat.command.moderation;
+
+import fredboat.command.util.HelpCommand;
+import fredboat.commandmeta.abs.Command;
+import fredboat.commandmeta.abs.CommandContext;
+import fredboat.commandmeta.abs.IModerationCommand;
+import fredboat.db.EntityReader;
+import fredboat.db.EntityWriter;
+import fredboat.db.entity.GuildPermissions;
+import fredboat.feature.togglz.FeatureFlags;
+import fredboat.messaging.CentralMessaging;
+import fredboat.messaging.internal.Context;
+import fredboat.perms.PermissionLevel;
+import fredboat.perms.PermsUtil;
+import fredboat.shared.constant.BotConstants;
+import fredboat.util.ArgumentUtil;
+import net.dv8tion.jda.core.EmbedBuilder;
+import net.dv8tion.jda.core.Permission;
+import net.dv8tion.jda.core.entities.*;
+import net.dv8tion.jda.core.utils.PermissionUtil;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BlacklistCommand extends Command implements IModerationCommand {
+    @Override
+    public void onInvoke(@Nonnull CommandContext context) {
+        if (!FeatureFlags.PERMISSIONS.isActive()) {
+            context.reply("Permissions are currently disabled.");
+            return;
+        }
+        String[] args = context.args;
+        if (args.length < 2) {
+            HelpCommand.sendFormattedCommandHelp(context);
+            return;
+        }
+
+        switch (args[1]) {
+            case "del":
+            case "delete":
+            case "remove":
+            case "rem":
+            case "rm":
+                if (!PermsUtil.checkPermsWithFeedback(PermissionLevel.ADMIN, context)) return;
+
+                if (args.length < 3) {
+                    HelpCommand.sendFormattedCommandHelp(context);
+                    return;
+                }
+
+                remove(context);
+                break;
+            case "add":
+                if (!PermsUtil.checkPermsWithFeedback(PermissionLevel.ADMIN, context)) return;
+
+                if (args.length < 3) {
+                    HelpCommand.sendFormattedCommandHelp(context);
+                    return;
+                }
+
+                add(context);
+                break;
+            case "list":
+            case "ls":
+                list(context);
+                break;
+            default:
+                HelpCommand.sendFormattedCommandHelp(context);
+                break;
+        }
+    }
+
+    private void remove(CommandContext context) {
+        Guild guild = context.guild;
+        String term = ArgumentUtil.getSearchTerm(context.msg, context.args, 2);
+
+        List<IMentionable> search = new ArrayList<>();
+        search.addAll(ArgumentUtil.fuzzyRoleSearch(guild, term));
+        search.addAll(ArgumentUtil.fuzzyMemberSearch(guild, term, false));
+        GuildPermissions gp = EntityReader.getGuildPermissions(guild);
+
+        IMentionable selected = ArgumentUtil.checkSingleFuzzySearchResult(search, context, term);
+        if (selected == null) return;
+
+        if (!gp.getBlacklistedList().contains(mentionableToId(selected))) {
+            context.replyWithName(context. i18nFormat("permsNotAdded", "`" + mentionableToName(selected) + "`", "`" + PermissionLevel.BLACKLISTED + "`"));
+            return;
+        }
+
+        List<String> newList = new ArrayList<>(gp.getBlacklistedList());
+        newList.remove(mentionableToId(selected));
+        gp.setBlacklistedList(newList);
+        EntityWriter.mergeGuildPermissions(gp);
+
+        context.replyWithName(context.i18nFormat("permsRemoved", mentionableToName(selected), PermissionLevel.BLACKLISTED));
+    }
+
+    private void add(CommandContext context) {
+        Guild guild = context.guild;
+        String term = ArgumentUtil.getSearchTerm(context.msg, context.args, 2);
+
+        List<IMentionable> list = new ArrayList<>();
+        list.addAll(ArgumentUtil.fuzzyRoleSearch(guild, term));
+        list.addAll(ArgumentUtil.fuzzyMemberSearch(guild, term, false));
+        GuildPermissions gp = EntityReader.getGuildPermissions(guild);
+
+        IMentionable selected = ArgumentUtil.checkSingleFuzzySearchResult(list, context, term);
+        if (selected == null) return;
+
+        if (gp.getBlacklistedList().contains(mentionableToId(selected))) {
+            context.replyWithName(context.i18nFormat("permsAlreadyAdded", "`" + mentionableToName(selected) + "`", "`" + PermissionLevel.BLACKLISTED + "`"));
+            return;
+        }
+
+        List<String> newList = new ArrayList<>(gp.getBlacklistedList());
+        newList.add(mentionableToId(selected));
+
+        if (!PermissionUtil.checkPermission(context.invoker, Permission.ADMINISTRATOR)
+                && !PermsUtil.checkList(newList, context.invoker)) {
+            context.replyWithName("You cant add this to the Blacklisted list as it would add yourself to the blacklist!");
+            return;
+        }
+
+        gp.setBlacklistedList(newList);
+        EntityWriter.mergeGuildPermissions(gp);
+
+        context.replyWithName(context.i18nFormat("permsAdded", mentionableToName(selected), PermissionLevel.BLACKLISTED));
+    }
+
+    private void list(CommandContext context) {
+        Guild guild = context.guild;
+        Member invoker = context.invoker;
+        GuildPermissions gp = EntityReader.getGuildPermissions(guild);
+
+        List<IMentionable> mentionables = idsToMentionables(guild, gp.getBlacklistedList());
+
+        StringBuilder roleMentions = new StringBuilder();
+        StringBuilder memberMentions = new StringBuilder();
+
+        for (IMentionable mentionable : mentionables) {
+            if (mentionable instanceof Role) {
+                if (((Role) mentionable).isPublicRole()) {
+                    roleMentions.append("@everyone").append("\n"); // Prevents ugly double double @@
+                } else {
+                    roleMentions.append(mentionable.getAsMention()).append("\n");
+                }
+            } else {
+                memberMentions.append(mentionable.getAsMention()).append("\n");
+            }
+        }
+
+        PermissionLevel invokerPerms = PermsUtil.getPerms(invoker);
+        boolean isBlacklisted = PermsUtil.isBlacklisted(invoker);
+
+        if (roleMentions.length() == 0) roleMentions = new StringBuilder("<none>");
+        if (memberMentions.length() == 0) memberMentions = new StringBuilder("<none>");
+
+        EmbedBuilder eb = CentralMessaging.getClearThreadLocalEmbedBuilder()
+                .setColor(BotConstants.FREDBOAT_COLOR)
+                .setTitle("User and Roles which are Blacklisted")
+                .setAuthor(invoker.getEffectiveName(), null, invoker.getUser().getAvatarUrl())
+                .addField("Roles", roleMentions.toString(), true)
+                .addField("Members", memberMentions.toString(), true)
+                .addField(invoker.getEffectiveName(), (isBlacklisted ? ":white_check_mark:" : ":x:") + " (" + invokerPerms + ")", false);
+        context.reply(CentralMessaging.addFooter(eb, guild.getSelfMember()).build());
+    }
+
+    private static String mentionableToId(IMentionable mentionable) {
+        if (mentionable instanceof ISnowflake) {
+            return ((ISnowflake) mentionable).getId();
+        } else if (mentionable instanceof Member) {
+            return ((Member) mentionable).getUser().getId();
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    private static String mentionableToName(IMentionable mentionable) {
+        if (mentionable instanceof Role) {
+            return ((Role) mentionable).getName();
+        } else if (mentionable instanceof Member) {
+            return ((Member) mentionable).getUser().getName();
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    private static List<IMentionable> idsToMentionables(Guild guild, List<String> list) {
+        List<IMentionable> out = new ArrayList<>();
+
+        for (String id : list) {
+            if (id.equals("")) continue;
+
+            if (guild.getRoleById(id) != null) {
+                out.add(guild.getRoleById(id));
+                continue;
+            }
+
+            if (guild.getMemberById(id) != null) {
+                out.add(guild.getMemberById(id));
+            }
+        }
+
+        return out;
+    }
+
+    @Nonnull
+    @Override
+    public String help(@Nonnull Context context) {
+        String usage = "{0}{1} add <role/user>\n{0}{1} del <role/user>\n{0}{1} list\n#";
+        return usage + "Add or Remove users from the Blacklist";
+    }
+}

--- a/FredBoat/src/main/java/fredboat/command/moderation/BlacklistCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/BlacklistCommand.java
@@ -117,7 +117,7 @@ public class BlacklistCommand extends Command implements IModerationCommand {
         newList.add(mentionableToId(selected));
 
         if (!PermissionUtil.checkPermission(context.invoker, Permission.ADMINISTRATOR)
-                && !PermsUtil.checkList(newList, context.invoker)) {
+                && PermsUtil.checkList(newList, context.invoker)) {
             context.replyWithName("You cant add this to the Blacklisted list as it would add yourself to the blacklist!");
             return;
         }

--- a/FredBoat/src/main/java/fredboat/commandmeta/init/MusicCommandInitializer.java
+++ b/FredBoat/src/main/java/fredboat/commandmeta/init/MusicCommandInitializer.java
@@ -125,6 +125,7 @@ public class MusicCommandInitializer {
         CommandRegistry.registerCommand("admin", new PermissionsCommand(PermissionLevel.ADMIN));
         CommandRegistry.registerCommand("dj", new PermissionsCommand(PermissionLevel.DJ));
         CommandRegistry.registerCommand("user", new PermissionsCommand(PermissionLevel.USER));
+        CommandRegistry.registerCommand("blacklist", new PermissionsCommand(PermissionLevel.BASE));
 
         // The null check is to ensure we can run this in a test run
         if (Config.CONFIG == null || Config.CONFIG.getDistribution() != DistributionEnum.PATRON) {

--- a/FredBoat/src/main/java/fredboat/commandmeta/init/MusicCommandInitializer.java
+++ b/FredBoat/src/main/java/fredboat/commandmeta/init/MusicCommandInitializer.java
@@ -125,7 +125,7 @@ public class MusicCommandInitializer {
         CommandRegistry.registerCommand("admin", new PermissionsCommand(PermissionLevel.ADMIN));
         CommandRegistry.registerCommand("dj", new PermissionsCommand(PermissionLevel.DJ));
         CommandRegistry.registerCommand("user", new PermissionsCommand(PermissionLevel.USER));
-        CommandRegistry.registerCommand("blacklist", new PermissionsCommand(PermissionLevel.BASE));
+        CommandRegistry.registerCommand("blacklist", new BlacklistCommand());
 
         // The null check is to ensure we can run this in a test run
         if (Config.CONFIG == null || Config.CONFIG.getDistribution() != DistributionEnum.PATRON) {

--- a/FredBoat/src/main/java/fredboat/db/entity/GuildPermissions.java
+++ b/FredBoat/src/main/java/fredboat/db/entity/GuildPermissions.java
@@ -71,16 +71,16 @@ public class GuildPermissions implements IEntity, Serializable {
     @Column(name = "list_user", nullable = false, columnDefinition = "text")
     private String userList = "";
 
-    @Column(name = "list_blocked", nullable = false, columnDefinition = "text")
+    @Column(name = "list_blacklist", nullable = false, columnDefinition = "text")
     private String blockedList = "";
 
-    public List<String> getBlockedList() {
+    public List<String> getBlacklistedList() {
         if (blockedList == null) return new ArrayList<>();
 
         return Arrays.asList(blockedList.split( " "));
     }
 
-    public void setBlockedList(List<String> list) {
+    public void setBlacklistedList(List<String> list) {
         StringBuilder str = new StringBuilder();
         for (String item : list) {
             str.append(item).append(" ");
@@ -142,8 +142,8 @@ public class GuildPermissions implements IEntity, Serializable {
                 return getDjList();
             case USER:
                 return getUserList();
-            case BASE:
-                return getBlockedList();
+            case BLACKLISTED:
+                return getBlacklistedList();
             default:
                 throw new IllegalArgumentException("Unexpected enum " + level);
         }
@@ -160,8 +160,8 @@ public class GuildPermissions implements IEntity, Serializable {
             case USER:
                 setUserList(list);
                 break;
-            case BASE:
-                setBlockedList(list);
+            case BLACKLISTED:
+                setBlacklistedList(list);
                 break;
             default:
                 throw new IllegalArgumentException("Unexpected enum " + level);

--- a/FredBoat/src/main/java/fredboat/db/entity/GuildPermissions.java
+++ b/FredBoat/src/main/java/fredboat/db/entity/GuildPermissions.java
@@ -71,6 +71,24 @@ public class GuildPermissions implements IEntity, Serializable {
     @Column(name = "list_user", nullable = false, columnDefinition = "text")
     private String userList = "";
 
+    @Column(name = "list_blocked", nullable = false, columnDefinition = "text")
+    private String blockedList = "";
+
+    public List<String> getBlockedList() {
+        if (blockedList == null) return new ArrayList<>();
+
+        return Arrays.asList(blockedList.split( " "));
+    }
+
+    public void setBlockedList(List<String> list) {
+        StringBuilder str = new StringBuilder();
+        for (String item : list) {
+            str.append(item).append(" ");
+        }
+
+        blockedList = str.toString().trim();
+    }
+
     public List<String> getAdminList() {
         if (adminList == null) return new ArrayList<>();
 
@@ -124,6 +142,8 @@ public class GuildPermissions implements IEntity, Serializable {
                 return getDjList();
             case USER:
                 return getUserList();
+            case BASE:
+                return getBlockedList();
             default:
                 throw new IllegalArgumentException("Unexpected enum " + level);
         }
@@ -139,6 +159,9 @@ public class GuildPermissions implements IEntity, Serializable {
                 break;
             case USER:
                 setUserList(list);
+                break;
+            case BASE:
+                setBlockedList(list);
                 break;
             default:
                 throw new IllegalArgumentException("Unexpected enum " + level);

--- a/FredBoat/src/main/java/fredboat/perms/PermissionLevel.java
+++ b/FredBoat/src/main/java/fredboat/perms/PermissionLevel.java
@@ -32,7 +32,8 @@ public enum PermissionLevel {
     ADMIN(3, "Admin"),
     DJ(2, "DJ"),
     USER(1, "User"),
-    BASE(0, "Base");
+    BASE(0, "Base"),
+    BLACKLISTED(-1, "Blacklisted");
 
     private int level;
     private String name;

--- a/FredBoat/src/main/java/fredboat/perms/PermsUtil.java
+++ b/FredBoat/src/main/java/fredboat/perms/PermsUtil.java
@@ -56,6 +56,7 @@ public class PermsUtil {
 
         GuildPermissions gp = EntityReader.getGuildPermissions(member.getGuild());
 
+        if (checkList(gp.getBlockedList(), member)) return PermissionLevel.BASE;
         if (checkList(gp.getAdminList(), member)) return PermissionLevel.ADMIN;
         if (checkList(gp.getDjList(), member)) return PermissionLevel.DJ;
         if (checkList(gp.getUserList(), member)) return PermissionLevel.USER;

--- a/FredBoat/src/main/java/fredboat/perms/PermsUtil.java
+++ b/FredBoat/src/main/java/fredboat/perms/PermsUtil.java
@@ -56,7 +56,7 @@ public class PermsUtil {
 
         GuildPermissions gp = EntityReader.getGuildPermissions(member.getGuild());
 
-        if (checkList(gp.getBlockedList(), member)) return PermissionLevel.BASE;
+        if (checkList(gp.getBlacklistedList(), member)) return PermissionLevel.BLACKLISTED; //Should we blacklist admins like its now ?
         if (checkList(gp.getAdminList(), member)) return PermissionLevel.ADMIN;
         if (checkList(gp.getDjList(), member)) return PermissionLevel.DJ;
         if (checkList(gp.getUserList(), member)) return PermissionLevel.USER;
@@ -66,6 +66,14 @@ public class PermsUtil {
 
     public static boolean checkPerms(PermissionLevel minLevel, Member member) {
         return getPerms(member).getLevel() >= minLevel.getLevel();
+    }
+
+    public static boolean isBlacklisted(Member member) {
+        if (!FeatureFlags.PERMISSIONS.isActive()) {
+            return false;
+        }
+        GuildPermissions gp = EntityReader.getGuildPermissions(member.getGuild());
+        return checkList(gp.getBlacklistedList(), member);
     }
 
     /**


### PR DESCRIPTION
This is not done by any means and I don't think this is how we imagine a blacklist for the permission system but this is just a simple starting point where I want to gather ideas on how to work on this.

I just slapped the preexisting Permission commands with the BASE level permission and updated the database to store blacklisted users
We likely need a whole new Command for this as the Strings from the I13n repo don't really fit with a blacklist and rather with a whitelist.

Essentially it works as its checking the blacklist level b4 any other db bound level but it would need some from self-add prevention so that users don't blacklist themselves by accident