### PR TITLE
small fix for the Permission command

### DIFF
--- a/FredBoat/src/main/java/fredboat/command/moderation/PermissionsCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/PermissionsCommand.java
@@ -125,7 +125,7 @@ public class PermissionsCommand extends Command implements IModerationCommand {
         if (selected == null) return;
 
         if (!gp.getFromEnum(permissionLevel).contains(mentionableToId(selected))) {
-            context.replyWithName(MessageFormat.format(I18n.get(context, "permsNotAdded"), "`" + mentionableToName(selected) + "`", "`" + permissionLevel + "`"));
+            context.replyWithName(context. i18nFormat("permsNotAdded", "`" + mentionableToName(selected) + "`", "`" + permissionLevel + "`"));
             return;
         }
 
@@ -159,7 +159,7 @@ public class PermissionsCommand extends Command implements IModerationCommand {
         if (selected == null) return;
 
         if (gp.getFromEnum(permissionLevel).contains(mentionableToId(selected))) {
-            context.replyWithName(MessageFormat.format(I18n.get(context, "permsAlreadyAdded"), "`" + mentionableToName(selected) + "`", "`" + permissionLevel + "`"));
+            context.replyWithName(context.i18nFormat("permsAlreadyAdded", "`" + mentionableToName(selected) + "`", "`" + permissionLevel + "`"));
             return;
         }
 

--- a/FredBoat/src/main/java/fredboat/command/moderation/PermissionsCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/PermissionsCommand.java
@@ -157,10 +157,14 @@ public class PermissionsCommand extends Command implements IModerationCommand {
         list.addAll(ArgumentUtil.fuzzyRoleSearch(guild, term));
         list.addAll(ArgumentUtil.fuzzyMemberSearch(guild, term, false));
         GuildPermissions gp = EntityReader.getGuildPermissions(guild);
-        list.removeAll(idsToMentionables(guild, gp.getFromEnum(permissionLevel)));
 
         IMentionable selected = ArgumentUtil.checkSingleFuzzySearchResult(list, context, term);
         if (selected == null) return;
+
+        if (gp.getFromEnum(permissionLevel).contains(mentionableToId(selected))) {
+            context.replyWithName(MessageFormat.format(I18n.get(context, "permsAlreadyAdded"), "`" + mentionableToName(selected) + "`", "`" + permissionLevel + "`"));
+            return;
+        }
 
         List<String> newList = new ArrayList<>(gp.getFromEnum(permissionLevel));
         newList.add(mentionableToId(selected));

--- a/FredBoat/src/main/java/fredboat/command/moderation/PermissionsCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/PermissionsCommand.java
@@ -116,21 +116,18 @@ public class PermissionsCommand extends Command implements IModerationCommand {
         Member invoker = context.invoker;
         String term = ArgumentUtil.getSearchTerm(context.msg, context.args, 2);
 
-        List<IMentionable> curList = new ArrayList<>();
         List<IMentionable> search = new ArrayList<>();
         search.addAll(ArgumentUtil.fuzzyRoleSearch(guild, term));
         search.addAll(ArgumentUtil.fuzzyMemberSearch(guild, term, false));
         GuildPermissions gp = EntityReader.getGuildPermissions(guild);
-        curList.addAll(idsToMentionables(guild, gp.getFromEnum(permissionLevel)));
 
-        List<IMentionable> itemsInBothLists = new ArrayList<>();
-
-        curList.forEach(mentionable -> {
-            if (search.contains(mentionable)) itemsInBothLists.add(mentionable);
-        });
-
-        IMentionable selected = ArgumentUtil.checkSingleFuzzySearchResult(itemsInBothLists, context, term);
+        IMentionable selected = ArgumentUtil.checkSingleFuzzySearchResult(search, context, term);
         if (selected == null) return;
+
+        if (!gp.getFromEnum(permissionLevel).contains(mentionableToId(selected))) {
+            context.replyWithName(MessageFormat.format(I18n.get(context, "permsNotAdded"), "`" + mentionableToName(selected) + "`", "`" + permissionLevel + "`"));
+            return;
+        }
 
         List<String> newList = new ArrayList<>(gp.getFromEnum(permissionLevel));
         newList.remove(mentionableToId(selected));

--- a/FredBoat/src/main/java/fredboat/util/ArgumentUtil.java
+++ b/FredBoat/src/main/java/fredboat/util/ArgumentUtil.java
@@ -138,7 +138,7 @@ public class ArgumentUtil {
 
     public static String getSearchTerm(Message message, String[] args, int argsToStrip) {
         String raw = message.getRawContent();
-        raw = raw.substring(args[0].length());
+        raw = raw.substring(args[0].length() + args[1].length() + 2); //arg0 is prefix, arg1 is add / remove and + 2 for the 2 spaces
         return raw.substring(raw.indexOf(args[argsToStrip]));
     }
 


### PR DESCRIPTION
This is related to #227 this improves the UX by instead of saying "Nothing found for `x`" for users that are already or are not in the list respectively 
it responds with this 
![image](https://user-images.githubusercontent.com/13600006/31060356-9159dc86-a712-11e7-8f91-46d67dc2e0f7.png)

While I tested the feature I noticed that ArgumentUtil#getSearchTerm() still could bug out if the search term was equal to `add` or `remove`
![image](https://user-images.githubusercontent.com/13600006/31060370-e5274588-a712-11e7-81ac-fa106f494be6.png)
So the second part of this pr completely strips the raw message from the prefix/command & the add/remove argument as well as the 2 spaces.

- [x] - This will need the merge of the I13n pr b4 this is can be merged
