### PR TITLE
⚰ Unirest

### DIFF
--- a/FredBoat/pom.xml
+++ b/FredBoat/pom.xml
@@ -87,12 +87,6 @@
             <version>1.0.6.1</version>
         </dependency>
         <dependency>
-            <!-- http client -->
-            <groupId>com.mashape.unirest</groupId>
-            <artifactId>unirest-java</artifactId>
-            <version>1.4.9</version>
-        </dependency>
-        <dependency>
             <!-- utility -->
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>

--- a/FredBoat/src/main/java/fredboat/Config.java
+++ b/FredBoat/src/main/java/fredboat/Config.java
@@ -26,7 +26,6 @@
 package fredboat;
 
 import com.google.common.base.CharMatcher;
-import com.mashape.unirest.http.exceptions.UnirestException;
 import fredboat.audio.player.PlayerLimitManager;
 import fredboat.command.admin.SentryDsnCommand;
 import fredboat.shared.constant.DistributionEnum;
@@ -260,7 +259,7 @@ public class Config {
             spotifyAudio = (Boolean) config.getOrDefault("enableSpotify", true);
             httpAudio = (Boolean) config.getOrDefault("enableHttp", false);
 
-        } catch (IOException | UnirestException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         } catch (YAMLException | ClassCastException e) {
             log.error("Could not parse the credentials and/or config yaml files! They are probably misformatted. " +

--- a/FredBoat/src/main/java/fredboat/agent/CarbonitexAgent.java
+++ b/FredBoat/src/main/java/fredboat/agent/CarbonitexAgent.java
@@ -29,6 +29,7 @@ import fredboat.Config;
 import fredboat.FredBoat;
 import fredboat.util.rest.Http;
 import net.dv8tion.jda.core.JDA;
+import okhttp3.Response;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
@@ -65,15 +66,20 @@ public class CarbonitexAgent extends FredBoatAgent {
             return;
         }
 
-        try {
-            final String response = Http.post("https://www.carbonitex.net/discord/data/botdata.php",
+        try (Response response = Http.post("https://www.carbonitex.net/discord/data/botdata.php",
                     Http.Params.of(
                             "key", key,
                             "servercount", Integer.toString(FredBoat.countAllGuilds())
                     ))
-                    .asString();
+                .execute()) {
 
-            log.info("Successfully posted the bot data to carbonitex.com: " + response);
+            //noinspection ConstantConditions
+            String content = response.body().string();
+            if (response.isSuccessful()) {
+                log.info("Successfully posted the bot data to carbonitex.com: {}", content);
+            } else {
+                log.warn("Failed to post stats to Carbonitex: {}\n{}", response.toString(), content);
+            }
         } catch (Exception e) {
             log.error("An error occurred while posting the bot data to carbonitex.com", e);
         }

--- a/FredBoat/src/main/java/fredboat/agent/CarbonitexAgent.java
+++ b/FredBoat/src/main/java/fredboat/agent/CarbonitexAgent.java
@@ -25,9 +25,9 @@
 
 package fredboat.agent;
 
-import com.mashape.unirest.http.Unirest;
 import fredboat.Config;
 import fredboat.FredBoat;
+import fredboat.util.rest.Http;
 import net.dv8tion.jda.core.JDA;
 import org.slf4j.LoggerFactory;
 
@@ -66,10 +66,13 @@ public class CarbonitexAgent extends FredBoatAgent {
         }
 
         try {
-            final String response = Unirest.post("https://www.carbonitex.net/discord/data/botdata.php")
-                    .field("key", key)
-                    .field("servercount", FredBoat.countAllGuilds())
-                    .asString().getBody();
+            final String response = Http.post("https://www.carbonitex.net/discord/data/botdata.php",
+                    Http.Params.of(
+                            "key", key,
+                            "servercount", Integer.toString(FredBoat.countAllGuilds())
+                    ))
+                    .asString();
+
             log.info("Successfully posted the bot data to carbonitex.com: " + response);
         } catch (Exception e) {
             log.error("An error occurred while posting the bot data to carbonitex.com", e);

--- a/FredBoat/src/main/java/fredboat/audio/player/LavalinkManager.java
+++ b/FredBoat/src/main/java/fredboat/audio/player/LavalinkManager.java
@@ -25,7 +25,6 @@
 
 package fredboat.audio.player;
 
-import com.mashape.unirest.http.exceptions.UnirestException;
 import fredboat.Config;
 import fredboat.FredBoat;
 import fredboat.util.DiscordUtil;
@@ -50,12 +49,7 @@ public class LavalinkManager {
     public void start() {
         if (!isEnabled()) return;
 
-        String userId;
-        try {
-            userId = DiscordUtil.getUserId(Config.CONFIG.getBotToken());
-        } catch (UnirestException e) {
-            throw new RuntimeException(e);
-        }
+        String userId = DiscordUtil.getUserId(Config.CONFIG.getBotToken());
 
         lavalink = new Lavalink(
                 userId,

--- a/FredBoat/src/main/java/fredboat/audio/source/PlaylistImportSourceManager.java
+++ b/FredBoat/src/main/java/fredboat/audio/source/PlaylistImportSourceManager.java
@@ -25,8 +25,6 @@
 
 package fredboat.audio.source;
 
-import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.exceptions.UnirestException;
 import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
@@ -35,6 +33,7 @@ import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import com.sedmelluq.discord.lavaplayer.track.*;
 import fredboat.audio.player.AbstractPlayer;
 import fredboat.audio.queue.PlaylistInfo;
+import fredboat.util.rest.Http;
 import org.slf4j.LoggerFactory;
 
 import java.io.DataInput;
@@ -154,9 +153,8 @@ public class PlaylistImportSourceManager implements AudioSourceManager, Playlist
     private List<String> loadAndParseTrackIds(String serviceName, String pasteId) {
         String response;
         try {
-            response = Unirest.get(PasteServiceConstants.PASTE_SERVICE_URLS.get(serviceName) + pasteId).asString()
-                    .getBody();
-        } catch (UnirestException ex) {
+            response = Http.get(PasteServiceConstants.PASTE_SERVICE_URLS.get(serviceName) + pasteId).asString();
+        } catch (IOException ex) {
             throw new FriendlyException(
                     "Couldn't load playlist. Either " + serviceName + " is down or the playlist does not exist.",
                     FriendlyException.Severity.FAULT, ex);

--- a/FredBoat/src/main/java/fredboat/command/admin/PlayerDebugCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/PlayerDebugCommand.java
@@ -25,7 +25,6 @@
 
 package fredboat.command.admin;
 
-import com.mashape.unirest.http.exceptions.UnirestException;
 import fredboat.audio.player.GuildPlayer;
 import fredboat.audio.player.PlayerRegistry;
 import fredboat.commandmeta.abs.Command;
@@ -35,13 +34,17 @@ import fredboat.messaging.internal.Context;
 import fredboat.perms.PermissionLevel;
 import fredboat.util.TextUtils;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.io.IOException;
 
 public class PlayerDebugCommand extends Command implements ICommandRestricted {
+
+    private static final Logger log = LoggerFactory.getLogger(PlayerDebugCommand.class);
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
@@ -61,8 +64,10 @@ public class PlayerDebugCommand extends Command implements ICommandRestricted {
         
         try {
             context.reply(TextUtils.postToPasteService(a.toString()));
-        } catch (UnirestException ex) {
-            Logger.getLogger(PlayerDebugCommand.class.getName()).log(Level.SEVERE, null, ex);
+        } catch (IOException | JSONException e) {
+            String message = "Failed to upload to any pasteservice.";
+            log.error(message, e);
+            context.reply(message);
         }
     }
 

--- a/FredBoat/src/main/java/fredboat/command/fun/AkinatorCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/fun/AkinatorCommand.java
@@ -25,15 +25,16 @@
 
 package fredboat.command.fun;
 
-import com.mashape.unirest.http.exceptions.UnirestException;
 import fredboat.FredBoat;
 import fredboat.commandmeta.abs.Command;
 import fredboat.commandmeta.abs.CommandContext;
 import fredboat.commandmeta.abs.IFunCommand;
 import fredboat.feature.AkinatorListener;
 import fredboat.messaging.internal.Context;
+import org.json.JSONException;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
 
 public class AkinatorCommand extends Command implements IFunCommand {
 
@@ -43,8 +44,8 @@ public class AkinatorCommand extends Command implements IFunCommand {
             String userId = context.invoker.getUser().getId();
             AkinatorListener akinator = new AkinatorListener(context);
             FredBoat.getListenerBot().putListener(userId, akinator);
-        } catch (UnirestException ex) {
-            throw new RuntimeException(ex);
+        } catch (IOException | JSONException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/FredBoat/src/main/java/fredboat/command/fun/JokeCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/fun/JokeCommand.java
@@ -25,24 +25,27 @@
 
 package fredboat.command.fun;
 
-import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.exceptions.UnirestException;
 import fredboat.commandmeta.abs.Command;
 import fredboat.commandmeta.abs.CommandContext;
 import fredboat.commandmeta.abs.IFunCommand;
 import fredboat.messaging.internal.Context;
+import fredboat.util.rest.Http;
+import org.json.JSONException;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.io.IOException;
 
 public class JokeCommand extends Command implements IFunCommand {
+
+    private static final Logger log = LoggerFactory.getLogger(JokeCommand.class);
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
         try {
-            JSONObject object = Unirest.get("http://api.icndb.com/jokes/random").asJson().getBody().getObject();
+            JSONObject object = Http.get("http://api.icndb.com/jokes/random").asJson();
 
             if (!"success".equals(object.getString("type"))) {
                 throw new RuntimeException("Couldn't gather joke ;|");
@@ -60,8 +63,9 @@ public class JokeCommand extends Command implements IFunCommand {
             joke = joke.replaceAll("&quot;", "\"");
 
             context.reply(joke);
-        } catch (UnirestException ex) {
-            Logger.getLogger(JokeCommand.class.getName()).log(Level.SEVERE, null, ex);
+        } catch (IOException | JSONException e) {
+            log.error("Failed to fetch joke", e);
+            context.reply(context.i18n("Please try again later."));//todo i18n a generic try again error message for api dependent commands
         }
     }
 

--- a/FredBoat/src/main/java/fredboat/command/music/info/ExportCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/info/ExportCommand.java
@@ -25,7 +25,6 @@
 
 package fredboat.command.music.info;
 
-import com.mashape.unirest.http.exceptions.UnirestException;
 import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import fredboat.audio.player.GuildPlayer;
@@ -37,11 +36,18 @@ import fredboat.commandmeta.abs.CommandContext;
 import fredboat.commandmeta.abs.IMusicCommand;
 import fredboat.messaging.internal.Context;
 import fredboat.util.TextUtils;
+import org.json.JSONException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
 import java.util.List;
 
 public class ExportCommand extends Command implements IMusicCommand {
+
+    private static final Logger log = LoggerFactory.getLogger(ExportCommand.class);
+
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
@@ -66,7 +72,8 @@ public class ExportCommand extends Command implements IMusicCommand {
         try {
             String url = TextUtils.postToPasteService(out) + ".fredboat";
             context.reply(context.i18nFormat("exportPlaylistResulted", url));
-        } catch (UnirestException ex) {
+        } catch (IOException | JSONException e) {
+            log.error("Failed to upload to any pasteservice.", e);
             throw new MessagingException(context.i18n("exportPlaylistFail"));
         }
         

--- a/FredBoat/src/main/java/fredboat/command/music/info/NowplayingCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/info/NowplayingCommand.java
@@ -25,8 +25,6 @@
 
 package fredboat.command.music.info;
 
-import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.exceptions.UnirestException;
 import com.sedmelluq.discord.lavaplayer.source.bandcamp.BandcampAudioTrack;
 import com.sedmelluq.discord.lavaplayer.source.beam.BeamAudioTrack;
 import com.sedmelluq.discord.lavaplayer.source.http.HttpAudioTrack;
@@ -44,6 +42,7 @@ import fredboat.messaging.CentralMessaging;
 import fredboat.messaging.internal.Context;
 import fredboat.shared.constant.BotConstants;
 import fredboat.util.TextUtils;
+import fredboat.util.rest.Http;
 import fredboat.util.rest.YoutubeAPI;
 import fredboat.util.rest.YoutubeVideo;
 import net.dv8tion.jda.core.EmbedBuilder;
@@ -52,6 +51,7 @@ import org.json.XML;
 
 import javax.annotation.Nonnull;
 import java.awt.*;
+import java.io.IOException;
 
 public class NowplayingCommand extends Command implements IMusicCommand {
 
@@ -157,7 +157,7 @@ public class NowplayingCommand extends Command implements IMusicCommand {
 
     private EmbedBuilder getBeamEmbed(AudioTrackContext atc, BeamAudioTrack at) {
         try {
-            JSONObject json = Unirest.get("https://beam.pro/api/v1/channels/" + at.getInfo().author).asJson().getBody().getObject();
+            JSONObject json = Http.get("https://beam.pro/api/v1/channels/" + at.getInfo().author).asJson();
 
             return CentralMessaging.getClearThreadLocalEmbedBuilder()
                     .setAuthor(at.getInfo().author, "https://beam.pro/" + at.getInfo().author, json.getJSONObject("user").getString("avatarUrl"))
@@ -166,14 +166,14 @@ public class NowplayingCommand extends Command implements IMusicCommand {
                     .setImage(json.getJSONObject("thumbnail").getString("url"))
                     .setColor(new Color(77, 144, 244));
 
-        } catch (UnirestException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
     static EmbedBuilder getGensokyoRadioEmbed(Context context) {
         try {
-            JSONObject data = XML.toJSONObject(Unirest.get("https://gensokyoradio.net/xml/").asString().getBody()).getJSONObject("GENSOKYORADIODATA");
+            JSONObject data = XML.toJSONObject(Http.get("https://gensokyoradio.net/xml/").asString()).getJSONObject("GENSOKYORADIODATA");
 
             String rating = data.getJSONObject("MISC").getInt("TIMESRATED") == 0 ?
                     context.i18n("noneYet") :
@@ -202,7 +202,7 @@ public class NowplayingCommand extends Command implements IMusicCommand {
                     .setImage(albumArt)
                     .setColor(new Color(66, 16, 80));
 
-        } catch (UnirestException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/FredBoat/src/main/java/fredboat/command/util/MALCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/util/MALCommand.java
@@ -60,11 +60,11 @@ public class MALCommand extends Command implements IUtilCommand {
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(MALCommand.class);
     private static Pattern regex = Pattern.compile("^\\S+\\s+([\\W\\w]*)");
 
-    //MALs API is wonky af and loves to timeout requests, so we are setting rather strict ones for its requests
+    //MALs API is wonky af and loves to take its time to answer requests, so we are setting rather high time outs
     private static OkHttpClient malHttpClient = new OkHttpClient.Builder()
-            .connectTimeout(5, TimeUnit.SECONDS)
-            .readTimeout(5, TimeUnit.SECONDS)
-            .writeTimeout(5, TimeUnit.SECONDS)
+            .connectTimeout(120, TimeUnit.SECONDS)
+            .readTimeout(120, TimeUnit.SECONDS)
+            .writeTimeout(120, TimeUnit.SECONDS)
             .build();
 
     @Override
@@ -99,13 +99,11 @@ public class MALCommand extends Command implements IUtilCommand {
             // we will try a user search instead
         }
 
-        request = Http.get("http://myanimelist.net/search/prefix.json",
+        request = request.url("http://myanimelist.net/search/prefix.json",
                 Http.Params.of(
                         "type", "user",
                         "keyword", term
-                ))
-                .auth(Credentials.basic(Config.CONFIG.getMalUser(), Config.CONFIG.getMalPassword()))
-                .client(malHttpClient);
+                ));
 
         try {
             if (handleUser(context, request.asString())) {

--- a/FredBoat/src/main/java/fredboat/command/util/MALCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/util/MALCommand.java
@@ -25,15 +25,15 @@
 
 package fredboat.command.util;
 
-import com.mashape.unirest.http.HttpResponse;
-import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.exceptions.UnirestException;
 import fredboat.Config;
 import fredboat.FredBoat;
 import fredboat.commandmeta.abs.Command;
 import fredboat.commandmeta.abs.CommandContext;
 import fredboat.commandmeta.abs.IUtilCommand;
 import fredboat.messaging.internal.Context;
+import fredboat.util.rest.Http;
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
 import org.apache.commons.text.StringEscapeUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -42,8 +42,10 @@ import org.json.XML;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -58,6 +60,13 @@ public class MALCommand extends Command implements IUtilCommand {
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(MALCommand.class);
     private static Pattern regex = Pattern.compile("^\\S+\\s+([\\W\\w]*)");
 
+    //MALs API is wonky af and loves to timeout requests, so we are setting rather strict ones for its requests
+    private static OkHttpClient malHttpClient = new OkHttpClient.Builder()
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(5, TimeUnit.SECONDS)
+            .writeTimeout(5, TimeUnit.SECONDS)
+            .build();
+
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
         Matcher matcher = regex.matcher(context.msg.getContent());
@@ -70,38 +79,43 @@ public class MALCommand extends Command implements IUtilCommand {
         String term = matcher.group(1).replace(' ', '+').trim();
         log.debug("TERM:" + term);
 
-        //MALs API is currently wonky af, so we are setting rather strict timeouts for its requests
-        Unirest.setTimeouts(5000, 10000);
         FredBoat.executor.submit(() -> requestAsync(term, context));
-        //back to defaults
-        Unirest.setTimeouts(10000, 60000);
     }
 
+    //attempts to find an anime with the provided search term, and if that's not possible looks for a user
     private void requestAsync(String term, CommandContext context) {
+        Http.SimpleRequest request = Http.get("https://myanimelist.net/api/anime/search.xml",
+                Http.Params.of(
+                        "q", term
+                ))
+                .auth(Credentials.basic(Config.CONFIG.getMalUser(), Config.CONFIG.getMalPassword()))
+                .client(malHttpClient);
+
         try {
-            HttpResponse<String> response = Unirest.get("https://myanimelist.net/api/anime/search.xml")
-                    .queryString("q", term)
-                    .basicAuth(Config.CONFIG.getMalUser(), Config.CONFIG.getMalPassword())
-                    .asString();
-
-            String body = response.getBody();
-            if (body != null && body.length() > 0) {
-                if (handleAnime(context, term, body)) {
-                    return;
-                }
+            if (handleAnime(context, term, request.asString())) {
+                return; //success
             }
-            response = Unirest.get("http://myanimelist.net/search/prefix.json")
-                    .queryString("type", "user")
-                    .queryString("keyword", term)
-                    .basicAuth(Config.CONFIG.getMalUser(), Config.CONFIG.getMalPassword())
-                    .asString();
-            body = response.getBody();
-
-            handleUser(context, body);
-        } catch (UnirestException ex) {
-            context.reply(context.i18nFormat("malNoResults", context.invoker.getEffectiveName()));
-            log.warn("MAL request blew up", ex);
+        } catch (IOException | JSONException ignored) {
+            // we will try a user search instead
         }
+
+        request = Http.get("http://myanimelist.net/search/prefix.json",
+                Http.Params.of(
+                        "type", "user",
+                        "keyword", term
+                ))
+                .auth(Credentials.basic(Config.CONFIG.getMalUser(), Config.CONFIG.getMalPassword()))
+                .client(malHttpClient);
+
+        try {
+            if (handleUser(context, request.asString())) {
+                return; //succcess
+            }
+        } catch (IOException | JSONException e) {
+            log.warn("MAL request blew up", e);
+        }
+
+        context.reply(context.i18nFormat("malNoResults", context.invoker.getEffectiveName()));
     }
 
     private boolean handleAnime(CommandContext context, String terms, String body) {

--- a/FredBoat/src/main/java/fredboat/feature/AkinatorListener.java
+++ b/FredBoat/src/main/java/fredboat/feature/AkinatorListener.java
@@ -25,17 +25,17 @@
 
 package fredboat.feature;
 
-import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.exceptions.UnirestException;
 import fredboat.FredBoat;
 import fredboat.event.UserListener;
 import fredboat.messaging.internal.Context;
 import fredboat.messaging.internal.LeakSafeContext;
+import fredboat.util.rest.Http;
 import net.dv8tion.jda.core.entities.Channel;
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
-import org.apache.commons.text.RandomStringGenerator;
+import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.IOException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -45,11 +45,11 @@ public final class AkinatorListener extends UserListener {
 
     private static final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(10);
 
-    private final String NEW_SESSION_URL = "http://api-en4.akinator.com/ws/new_session?partner=1";
-    private final String ANSWER_URL = "http://api-en4.akinator.com/ws/answer";
-    private final String GET_GUESS_URL = "http://api-en4.akinator.com/ws/list";
-    private final String CHOICE_URL = "http://api-en4.akinator.com/ws/choice";
-    private final String EXCLUSION_URL = "http://api-en4.akinator.com/ws/exclusion";
+    private static final String NEW_SESSION_URL = "http://api-en4.akinator.com/ws/new_session?partner=1";
+    private static final String ANSWER_URL = "http://api-en4.akinator.com/ws/answer";
+    private static final String GET_GUESS_URL = "http://api-en4.akinator.com/ws/list";
+    private static final String CHOICE_URL = "http://api-en4.akinator.com/ws/choice";
+    private static final String EXCLUSION_URL = "http://api-en4.akinator.com/ws/exclusion";
 
     private final LeakSafeContext context;
     private final String channelId;
@@ -65,7 +65,7 @@ public final class AkinatorListener extends UserListener {
     private Future timeoutTask;
 
 
-    public AkinatorListener(Context context) throws UnirestException {
+    public AkinatorListener(Context context) throws IOException, JSONException {
         this.context = new LeakSafeContext(context);
         this.userId = context.getMember().getUser().getId();
         this.channelId = context.getTextChannel().getId();
@@ -73,12 +73,11 @@ public final class AkinatorListener extends UserListener {
         context.sendTyping();
 
         //Start new session
-        RandomStringGenerator randomStringGenerator = new RandomStringGenerator.Builder().build();
-        JSONObject json = Unirest.get(NEW_SESSION_URL)
-                .queryString("player", randomStringGenerator.generate(16))
-                .asJson().getBody().getObject();
-        stepInfo = new StepInfo(json);
+        Http.SimpleRequest request = Http.get(NEW_SESSION_URL, Http.Params.of(
+                "player", userId
+        ));
 
+        stepInfo = new StepInfo(request.asJson());
         signature = stepInfo.getSignature();
         session = stepInfo.getSession();
 
@@ -101,7 +100,7 @@ public final class AkinatorListener extends UserListener {
         lastQuestionWasGuess = false;
     }
 
-    private void sendGuess() throws UnirestException {
+    private void sendGuess() throws IOException, JSONException {
         guess = new Guess();
         String out = "Is this your character?\n" + guess.toString() + "\n[yes/no]";
         context.reply(out);
@@ -109,14 +108,14 @@ public final class AkinatorListener extends UserListener {
     }
 
     private void answerQuestion(byte answer) {
+        Http.SimpleRequest request = Http.get(ANSWER_URL, Http.Params.of(
+                "session", session,
+                "signature", signature,
+                "step", String.valueOf(stepInfo.getStepNum()),
+                "answer", Byte.toString(answer)
+        ));
         try {
-            JSONObject json = Unirest.get(ANSWER_URL)
-                    .queryString("session", session)
-                    .queryString("signature", signature)
-                    .queryString("step", stepInfo.getStepNum())
-                    .queryString("answer", answer)
-                    .asJson().getBody().getObject();
-            stepInfo = new StepInfo(json);
+            stepInfo = new StepInfo(request.asJson());
 
             if (stepInfo.gameOver) {
                 context.reply("Bravo !\n"
@@ -131,7 +130,7 @@ public final class AkinatorListener extends UserListener {
             } else {
                 sendNextQuestion();
             }
-        } catch (UnirestException ex) {
+        } catch (IOException | JSONException ex) {
             throw new RuntimeException(ex);
         }
     }
@@ -139,28 +138,35 @@ public final class AkinatorListener extends UserListener {
     private void answerGuess(byte answer) {
         try {
             if (answer == 0) {
-                Unirest.get(CHOICE_URL)
-                        .queryString("session", session)
-                        .queryString("signature", signature)
-                        .queryString("step", stepInfo.getStepNum())
-                        .queryString("element", guess.getId())
-                        .asString();
-                context.reply("Great ! Guessed right one more time.\n"
+                Http.get(CHOICE_URL,
+                        Http.Params.of(
+                                "session", session,
+                                "signature", signature,
+                                "step", Integer.toString(stepInfo.getStepNum()),
+                                "element", guess.getId()
+                        ))
+                        .execute()
+                        .close();
+
+                context.reply("Great! Guessed right one more time.\n"
                         + "I love playing with you!\n"
                         + "<http://akinator.com>");
                 FredBoat.getListenerBot().removeListener(userId);
             } else if (answer == 1) {
-                Unirest.get(EXCLUSION_URL)
-                        .queryString("session", session)
-                        .queryString("signature", signature)
-                        .queryString("step", stepInfo.getStepNum())
-                        .queryString("forward_answer", answer)
-                        .asString();
+                Http.get(EXCLUSION_URL,
+                        Http.Params.of(
+                                "session", session,
+                                "signature", signature,
+                                "step", Integer.toString(stepInfo.getStepNum()),
+                                "forward_answer", Byte.toString(answer)
+                        ))
+                        .execute()
+                        .close();
 
                 lastQuestionWasGuess = false;
                 sendNextQuestion();
             }
-        } catch (UnirestException ex) {
+        } catch (IOException ex) {
             throw new RuntimeException(ex);
         }
     }
@@ -237,7 +243,7 @@ public final class AkinatorListener extends UserListener {
         private int stepNum;
         private double progression;
 
-        StepInfo(JSONObject json) {
+        StepInfo(JSONObject json) throws JSONException {
             String completion = json.getString("completion");
             if ("OK".equalsIgnoreCase(completion)) {
                 JSONObject params = json.getJSONObject("parameters");
@@ -288,16 +294,14 @@ public final class AkinatorListener extends UserListener {
         private final String pseudo;
         private final String imgPath;
 
-        Guess() throws UnirestException {
-            JSONObject json = Unirest.get(GET_GUESS_URL)
-                    .queryString("session", session)
-                    .queryString("signature", signature)
-                    .queryString("step", stepInfo.getStepNum())
-                    .asJson()
-                    .getBody()
-                    .getObject();
+        Guess() throws IOException, JSONException {
+            Http.SimpleRequest request = Http.get(GET_GUESS_URL, Http.Params.of(
+                    "session", session,
+                    "signature", signature,
+                    "step", Integer.toString(stepInfo.getStepNum())
+            ));
 
-            JSONObject character = json.getJSONObject("parameters")
+            JSONObject character = request.asJson().getJSONObject("parameters")
                     .getJSONArray("elements")
                     .getJSONObject(0)
                     .getJSONObject("element");

--- a/FredBoat/src/main/java/fredboat/feature/PatronageChecker.java
+++ b/FredBoat/src/main/java/fredboat/feature/PatronageChecker.java
@@ -28,9 +28,9 @@ package fredboat.feature;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.mashape.unirest.http.Unirest;
 import fredboat.Config;
 import fredboat.shared.constant.DistributionEnum;
+import fredboat.util.rest.Http;
 import net.dv8tion.jda.core.entities.Guild;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -108,13 +108,14 @@ public class PatronageChecker {
         @SuppressWarnings("NullableProblems")
         @Override
         public Status load(String key) throws Exception {
+            //TODO prevent selfhosters from running this?
             try {
-                return new Status(Unirest.get(Config.CONFIG.getDistribution() == DistributionEnum.PATRON
-                        ? "https://patronapi.fredboat.com/api/drm/" + key
-                        : "http://localhost:4500/api/drm/" + key)
-                        .asJson()
-                        .getBody()
-                        .getObject());
+                return new Status(
+                        Http.get(Config.CONFIG.getDistribution() == DistributionEnum.PATRON
+                                ? "https://patronapi.fredboat.com/api/drm/" + key
+                                : "http://localhost:4500/api/drm/" + key)
+                                .asJson()
+                );
             } catch (Exception e) {
                 log.error("Caught exception while verifying patron status", e);
                 return new Status(); // Valid status, expires early

--- a/FredBoat/src/main/java/fredboat/util/rest/Http.java
+++ b/FredBoat/src/main/java/fredboat/util/rest/Http.java
@@ -1,0 +1,195 @@
+/*
+ *
+ * MIT License
+ *
+ * Copyright (c) 2017 Frederik Ar. Mikkelsen
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package fredboat.util.rest;
+
+import okhttp3.FormBody;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by napster on 03.10.17.
+ * <p>
+ * A Unirest-like wrapper with focus on convenience methods and classes for the OKHttpClient lib
+ */
+public class Http {
+
+    private static final Logger log = LoggerFactory.getLogger(Http.class);
+
+    public final static OkHttpClient defaultHttpClient = new OkHttpClient.Builder()
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .build();
+
+
+    @Nonnull
+    @CheckReturnValue
+    //if content type is left null we will assume it is text/plain UTF-8
+    public static SimpleRequest post(@Nonnull String url, @Nonnull String body, @Nullable String contentType) {
+        MediaType mediaType = contentType != null ? MediaType.parse(contentType) : MediaType.parse("text/plain");
+        return new SimpleRequest(new Request.Builder()
+                .post(RequestBody.create(mediaType, body))
+                .url(url));
+    }
+
+    @Nonnull
+    @CheckReturnValue
+    //post a simple form body made of string string key values
+    public static SimpleRequest post(@Nonnull String url, @Nonnull Params params) {
+        FormBody.Builder body = new FormBody.Builder();
+        for (Map.Entry<String, String> param : params.params.entrySet()) {
+            body.add(param.getKey(), param.getValue());
+        }
+        return new SimpleRequest(new Request.Builder()
+                .post(body.build())
+                .url(url));
+    }
+
+    @Nonnull
+    @CheckReturnValue
+    public static SimpleRequest get(@Nonnull String url) {
+        return new SimpleRequest(new Request.Builder()
+                .get()
+                .url(url));
+    }
+
+
+    @Nonnull
+    @CheckReturnValue
+    public static SimpleRequest get(@Nonnull String url, @Nonnull Params params) {
+        return new SimpleRequest(new Request.Builder()
+                .get()
+                .url(paramUrl(url, params.params).build()));
+    }
+
+    @Nonnull
+    @CheckReturnValue
+    private static HttpUrl.Builder paramUrl(@Nonnull String url, @Nonnull Map<String, String> params) {
+        //noinspection ConstantConditions
+        HttpUrl.Builder httpUrlBuilder = HttpUrl.parse(url).newBuilder();
+        for (Map.Entry<String, String> param : params.entrySet()) {
+            httpUrlBuilder.addQueryParameter(param.getKey(), param.getValue());
+        }
+        return httpUrlBuilder;
+    }
+
+    /**
+     * A simplified request.
+     */
+    public static class SimpleRequest {
+        private Request.Builder requestBuilder;
+        private OkHttpClient httpClient = defaultHttpClient;
+
+        public SimpleRequest(Request.Builder requestBuilder) {
+            this.requestBuilder = requestBuilder;
+        }
+
+        //set a custom client to execute this request with
+        @Nonnull
+        @CheckReturnValue
+        public SimpleRequest client(@Nonnull OkHttpClient httpClient) {
+            this.httpClient = httpClient;
+            return this;
+        }
+
+        //add a header
+        @Nonnull
+        @CheckReturnValue
+        public SimpleRequest header(@Nonnull String name, @Nonnull String value) {
+            requestBuilder.header(name, value);
+            return this;
+        }
+
+        //set an authorization header
+        @Nonnull
+        @CheckReturnValue
+        public SimpleRequest auth(@Nonnull String value) {
+            requestBuilder.header("Authorization", value);
+            return this;
+        }
+
+        //remember to close the response
+        @Nonnull
+        @CheckReturnValue
+        public Response execute() throws IOException {
+            return httpClient.newCall(requestBuilder.build()).execute();
+        }
+
+        //give me the content, don't care about error handling
+        @Nonnull
+        @CheckReturnValue
+        public String asString() throws IOException {
+            try (Response response = httpClient.newCall(requestBuilder.build()).execute()) {
+                //noinspection ConstantConditions
+                return response.body().string();
+            }
+        }
+
+        //give me the content, I don't care about error handling
+        // catching JSONExceptions when parsing the returned object is a good idea
+        @Nonnull
+        @CheckReturnValue
+        public JSONObject asJson() throws IOException {
+            return new JSONObject(asString());
+        }
+    }
+
+    /**
+     * Fancy wrapper for a string to string map with a factory method
+     */
+    public static class Params {
+        private Map<String, String> params = new HashMap<>();
+
+        //pass pairs of strings and you'll be fine
+        @Nonnull
+        @CheckReturnValue
+        public static Params of(@Nonnull String... pairs) {
+            if (pairs.length % 2 == 1) {
+                log.warn("Passed an uneven number of args to the Params wrapper, this is a likely bug.");
+            }
+            Params result = new Params();
+            for (int i = 0; i <= pairs.length / 2; i += 2) {
+                result.params.put(pairs[i], pairs[i + 1]);
+            }
+            return result;
+        }
+    }
+}

--- a/FredBoat/src/main/java/fredboat/util/rest/Http.java
+++ b/FredBoat/src/main/java/fredboat/util/rest/Http.java
@@ -32,6 +32,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import org.apache.commons.collections4.MapUtils;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,6 +123,13 @@ public class Http {
             this.requestBuilder = requestBuilder;
         }
 
+        @Nonnull
+        @CheckReturnValue
+        public SimpleRequest url(@Nonnull String url, @Nonnull Params params) {
+            requestBuilder.url(paramUrl(url, params.params).build());
+            return this;
+        }
+
         //set a custom client to execute this request with
         @Nonnull
         @CheckReturnValue
@@ -150,14 +158,16 @@ public class Http {
         @Nonnull
         @CheckReturnValue
         public Response execute() throws IOException {
-            return httpClient.newCall(requestBuilder.build()).execute();
+            Request req = requestBuilder.build();
+            log.debug("{} {}", req.method(), req.url().toString());
+            return httpClient.newCall(req).execute();
         }
 
         //give me the content, don't care about error handling
         @Nonnull
         @CheckReturnValue
         public String asString() throws IOException {
-            try (Response response = httpClient.newCall(requestBuilder.build()).execute()) {
+            try (Response response = this.execute()) {
                 //noinspection ConstantConditions
                 return response.body().string();
             }
@@ -186,9 +196,7 @@ public class Http {
                 log.warn("Passed an uneven number of args to the Params wrapper, this is a likely bug.");
             }
             Params result = new Params();
-            for (int i = 0; i <= pairs.length / 2; i += 2) {
-                result.params.put(pairs[i], pairs[i + 1]);
-            }
+            MapUtils.putAll(result.params, pairs);
             return result;
         }
     }

--- a/FredBoat/src/main/java/fredboat/util/rest/Http.java
+++ b/FredBoat/src/main/java/fredboat/util/rest/Http.java
@@ -200,4 +200,13 @@ public class Http {
             return result;
         }
     }
+
+    public static boolean isImage(Response response) {
+        String type = response.header("Content-Type");
+        return type != null
+                && (type.equals("image/jpeg")
+                || type.equals("image/png")
+                || type.equals("image/gif")
+                || type.equals("image/webp"));
+    }
 }

--- a/FredBoat/src/main/java/fredboat/util/rest/YoutubeVideo.java
+++ b/FredBoat/src/main/java/fredboat/util/rest/YoutubeVideo.java
@@ -25,13 +25,13 @@
 
 package fredboat.util.rest;
 
-import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.exceptions.UnirestException;
 import fredboat.Config;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -126,23 +126,21 @@ public class YoutubeVideo {
     }
 
     public String getChannelThumbUrl() {
+        Http.SimpleRequest request = Http.get(YoutubeAPI.YOUTUBE_CHANNEL,
+                Http.Params.of(
+                        "id", channelId,
+                        "key", Config.CONFIG.getRandomGoogleKey()
+                ));
         try {
-            JSONObject json = Unirest.get("https://www.googleapis.com/youtube/v3/channels?part=snippet&fields=items(snippet/thumbnails)")
-                    .queryString("id", channelId)
-                    .queryString("key", Config.CONFIG.getRandomGoogleKey())
-                    .asJson()
-                    .getBody()
-                    .getObject();
-
-            log.debug("Channel thumb response", json);
-
+            JSONObject json = request.asJson();
+            log.debug("Channel thumb response");
             return json.getJSONArray("items")
                     .getJSONObject(0)
                     .getJSONObject("snippet")
                     .getJSONObject("thumbnails")
                     .getJSONObject("default")
                     .getString("url");
-        } catch (UnirestException e) {
+        } catch (JSONException | IOException e) {
             log.error("Failed to get channel thumbnail", e);
             return null;
         }


### PR DESCRIPTION
Unirest is an unmaintained http lib. I didn't waste much thought into choosing a replacement, just picked okhttp as JDA uses it too. The thing about okhttp is while Unirest is static hell, OkHttp swings out really strong in the opposite direction being extremely object oriented which can be quite annoying at times, so part of this PR is a unirest-like okhttp wrapper [Http.java](https://github.com/Frederikam/FredBoat/commit/27eb8739d12af18b25f33fc278b67d89e73e7635#diff-2de669976a7936d93331ea8d5d69811c) which is good enough:tm: for our most common calls.

Looking for general feedback at this point.
Do not merge this before #290 and #338

I did test each of the replaced calls individually and all of them appear to be working, except the stats post to Carbonitex which I can't test since I do not own a Carbonitex key.