### PR TITLE
Always use the track uri in the export

### DIFF
--- a/FredBoat/src/main/java/fredboat/command/music/info/ExportCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/info/ExportCommand.java
@@ -25,7 +25,6 @@
 
 package fredboat.command.music.info;
 
-import com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeAudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import fredboat.audio.player.GuildPlayer;
 import fredboat.audio.player.PlayerRegistry;
@@ -59,14 +58,9 @@ public class ExportCommand extends Command implements IMusicCommand {
         
         List<AudioTrackContext> tracks = player.getRemainingTracks();
         String out = "";
-        
         for(AudioTrackContext atc : tracks){
             AudioTrack at = atc.getTrack();
-            if(at instanceof YoutubeAudioTrack){
-                out = out + "https://www.youtube.com/watch?v=" + at.getIdentifier() + "\n";
-            } else {
-                out = out + at.getIdentifier() + "\n";
-            }
+            out = out + at.getInfo().uri + "\n";
         }
         
         try {

--- a/FredBoat/src/main/java/fredboat/command/music/info/ExportCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/info/ExportCommand.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ExportCommand extends Command implements IMusicCommand {
 
@@ -55,14 +56,11 @@ public class ExportCommand extends Command implements IMusicCommand {
         if (player.isQueueEmpty()) {
             throw new MessagingException(context.i18n("exportEmpty"));
         }
-        
-        List<AudioTrackContext> tracks = player.getRemainingTracks();
-        String out = "";
-        for(AudioTrackContext atc : tracks){
-            AudioTrack at = atc.getTrack();
-            out = out + at.getInfo().uri + "\n";
-        }
-        
+
+        String out = player.getRemainingTracks().stream()
+                .map(atc -> atc.getTrack().getInfo().uri)
+                .collect(Collectors.joining("\n"));
+
         try {
             String url = TextUtils.postToPasteService(out) + ".fredboat";
             context.reply(context.i18nFormat("exportPlaylistResulted", url));


### PR DESCRIPTION
This is actually the same as the custom identifier in the YouTube case but makes all tracks exportable.