### PR TITLE
Add mention prefix, rework command argument parsing

### DIFF
--- a/FredBoat/src/main/java/fredboat/FredBoat.java
+++ b/FredBoat/src/main/java/fredboat/FredBoat.java
@@ -51,6 +51,7 @@ import net.dv8tion.jda.core.JDA;
 import net.dv8tion.jda.core.JDAInfo;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.TextChannel;
+import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.entities.VoiceChannel;
 import net.dv8tion.jda.core.events.ReadyEvent;
 import net.dv8tion.jda.core.hooks.EventListener;
@@ -370,6 +371,15 @@ public abstract class FredBoat {
         for (FredBoat fb : shards) {
             Guild g = fb.getJda().getGuildById(id);
             if (g != null) return g;
+        }
+        return null;
+    }
+
+    @Nullable
+    public static User getUserById(long id) {
+        for (FredBoat fb : shards) {
+            User u = fb.getJda().getUserById(id);
+            if (u != null) return u;
         }
         return null;
     }

--- a/FredBoat/src/main/java/fredboat/command/admin/AnnounceCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/AnnounceCommand.java
@@ -63,8 +63,7 @@ public class AnnounceCommand extends Command implements ICommandRestricted {
         if (players.isEmpty()) {
             return;
         }
-        String input = context.msg.getRawContent().substring(context.args[0].length() + 1);
-        String msg = HEAD + input;
+        String msg = HEAD + context.rawArgs;
 
         context.reply(String.format("[0/%d]", players.size()),
                 //success handler

--- a/FredBoat/src/main/java/fredboat/command/admin/CompileCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/CompileCommand.java
@@ -63,7 +63,7 @@ public class CompileCommand extends Command implements ICommandRestricted {
             Runtime rt = Runtime.getRuntime();
 
             String branch = "master";
-            if (context.args.length > 0) {
+            if (context.hasArguments()) {
                 branch = context.args[0];
             }
             String githubUser = "Frederikam";

--- a/FredBoat/src/main/java/fredboat/command/admin/CompileCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/CompileCommand.java
@@ -63,12 +63,12 @@ public class CompileCommand extends Command implements ICommandRestricted {
             Runtime rt = Runtime.getRuntime();
 
             String branch = "master";
-            if (context.args.length > 1) {
-                branch = context.args[1];
+            if (context.args.length > 0) {
+                branch = context.args[0];
             }
             String githubUser = "Frederikam";
-            if (context.args.length > 2) {
-                githubUser = context.args[2];
+            if (context.args.length > 1) {
+                githubUser = context.args[1];
             }
 
             //Clear any old update folder if it is still present

--- a/FredBoat/src/main/java/fredboat/command/admin/EvalCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/EvalCommand.java
@@ -71,7 +71,7 @@ public class EvalCommand extends Command implements ICommandRestricted {
         JDA jda = guild.getJDA();
         context.sendTyping();
 
-        final String source = context.msg.getRawContent().substring(context.args[0].length() + 1);
+        final String source = context.rawArgs;
 
         engine.put("jda", jda);
         engine.put("api", jda);

--- a/FredBoat/src/main/java/fredboat/command/admin/GetNodeCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/GetNodeCommand.java
@@ -41,17 +41,24 @@ public class GetNodeCommand extends Command implements ICommandRestricted {
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        Guild guild;
-        String[] args = context.args;
-        if (args.length == 2) {
-            long guildId = Long.parseUnsignedLong(args[1]);
-            guild = FredBoat.getGuildById(guildId);
+        if (!LavalinkManager.ins.isEnabled()) {
+            context.replyWithName("Lavalink is not enabled.");
+            return;
+        }
+
+        Guild guild = null;
+        if (context.args.length == 1) {
+            try {
+                long guildId = Long.parseUnsignedLong(context.args[0]);
+                guild = FredBoat.getGuildById(guildId);
+            } catch (NumberFormatException ignored) {
+            }
+            if (guild == null) {
+                context.reply("Guild not found for id " + context.args[0]);
+                return;
+            }
         } else {
             guild = context.guild;
-        }
-        if (guild == null) {
-            context.reply("Guild not found.");
-            return;
         }
         LavalinkSocket node = LavalinkManager.ins.getLavalink().getLink(guild).getCurrentSocket();
 

--- a/FredBoat/src/main/java/fredboat/command/admin/GetNodeCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/GetNodeCommand.java
@@ -47,7 +47,7 @@ public class GetNodeCommand extends Command implements ICommandRestricted {
         }
 
         Guild guild = null;
-        if (context.args.length == 1) {
+        if (context.hasArguments()) {
             try {
                 long guildId = Long.parseUnsignedLong(context.args[0]);
                 guild = FredBoat.getGuildById(guildId);

--- a/FredBoat/src/main/java/fredboat/command/admin/NodeAdminCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/NodeAdminCommand.java
@@ -43,11 +43,11 @@ public class NodeAdminCommand extends Command implements ICommandRestricted {
         if (!LavalinkManager.ins.isEnabled()) {
             context.reply("Lavalink is disabled");
         }
-        if (context.args.length == 1) {
+        if (context.args.length == 0) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
-        switch (context.args[1]) {
+        switch (context.args[0]) {
             case "del":
             case "delete":
             case "remove":
@@ -66,7 +66,7 @@ public class NodeAdminCommand extends Command implements ICommandRestricted {
     }
 
     private void remove(CommandContext context) {
-        int key = Integer.valueOf(context.args[2]);
+        int key = Integer.valueOf(context.args[1]);
         LavalinkManager.ins.getLavalink().removeNode(key);
         context.reply("Removed node #" + key);
     }
@@ -74,12 +74,12 @@ public class NodeAdminCommand extends Command implements ICommandRestricted {
     private void add(CommandContext context) {
         URI uri;
         try {
-            uri = new URI(context.args[2]);
+            uri = new URI(context.args[1]);
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
 
-        String password = context.args[3];
+        String password = context.args[2];
         LavalinkManager.ins.getLavalink().addNode(uri, password);
         context.reply("Added node: " + uri.toString());
     }

--- a/FredBoat/src/main/java/fredboat/command/admin/NodeAdminCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/NodeAdminCommand.java
@@ -43,7 +43,7 @@ public class NodeAdminCommand extends Command implements ICommandRestricted {
         if (!LavalinkManager.ins.isEnabled()) {
             context.reply("Lavalink is disabled");
         }
-        if (context.args.length == 0) {
+        if (!context.hasArguments()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
@@ -53,10 +53,18 @@ public class NodeAdminCommand extends Command implements ICommandRestricted {
             case "remove":
             case "rem":
             case "rm":
-                remove(context);
+                if (context.args.length < 2) {
+                    HelpCommand.sendFormattedCommandHelp(context);
+                } else {
+                    remove(context);
+                }
                 break;
             case "add":
-                add(context);
+                if (context.args.length < 3) {
+                    HelpCommand.sendFormattedCommandHelp(context);
+                } else {
+                    add(context);
+                }
                 break;
             case "list":
             default:

--- a/FredBoat/src/main/java/fredboat/command/admin/ReviveCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/ReviveCommand.java
@@ -46,15 +46,21 @@ public class ReviveCommand extends Command implements ICommandRestricted {
     public void onInvoke(@Nonnull CommandContext context) {
 
         int shardId;
+
+        if (!context.hasArguments()) {
+            HelpCommand.sendFormattedCommandHelp(context);
+            return;
+        }
+
         try {
-            if (context.args[0].equals("guild")) {
+            if (context.args.length > 1 && context.args[0].equals("guild")) {
                 long guildId = Long.valueOf(context.args[1]);
                 //https://discordapp.com/developers/docs/topics/gateway#sharding
                 shardId = (int) ((guildId >> 22) % Config.CONFIG.getNumShards());
-            } else
+            } else {
                 shardId = Integer.parseInt(context.args[0]);
-
-        } catch (NumberFormatException | IndexOutOfBoundsException e) {
+            }
+        } catch (NumberFormatException e) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }

--- a/FredBoat/src/main/java/fredboat/command/admin/ReviveCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/ReviveCommand.java
@@ -47,19 +47,19 @@ public class ReviveCommand extends Command implements ICommandRestricted {
 
         int shardId;
         try {
-            if (context.args[1].equals("guild")) {
-                long guildId = Long.valueOf(context.args[2]);
+            if (context.args[0].equals("guild")) {
+                long guildId = Long.valueOf(context.args[1]);
                 //https://discordapp.com/developers/docs/topics/gateway#sharding
                 shardId = (int) ((guildId >> 22) % Config.CONFIG.getNumShards());
             } else
-                shardId = Integer.parseInt(context.args[1]);
+                shardId = Integer.parseInt(context.args[0]);
 
         } catch (NumberFormatException | IndexOutOfBoundsException e) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
 
-        boolean force = (context.msg.getRawContent().toLowerCase().contains("force"));
+        boolean force = context.rawArgs.toLowerCase().contains("force");
 
         context.replyWithName("Attempting to revive shard " + shardId);
         try {

--- a/FredBoat/src/main/java/fredboat/command/admin/SentryDsnCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/SentryDsnCommand.java
@@ -54,13 +54,13 @@ public class SentryDsnCommand extends Command implements ICommandRestricted {
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        if (context.args.length < 2) {
+        if (context.rawArgs.isEmpty()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
-        String dsn = context.args[1];
+        String dsn = context.rawArgs;
 
-        if (dsn.equals("stop") || dsn.equals("clear")) {
+        if (dsn.equalsIgnoreCase("stop") || dsn.equalsIgnoreCase("clear")) {
             turnOff();
             context.replyWithName("Sentry service has been stopped");
         } else {

--- a/FredBoat/src/main/java/fredboat/command/admin/SentryDsnCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/SentryDsnCommand.java
@@ -54,7 +54,7 @@ public class SentryDsnCommand extends Command implements ICommandRestricted {
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        if (context.rawArgs.isEmpty()) {
+        if (!context.hasArguments()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }

--- a/FredBoat/src/main/java/fredboat/command/admin/SetAvatarCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/SetAvatarCommand.java
@@ -31,7 +31,7 @@ public class SetAvatarCommand extends Command implements ICommandRestricted {
         if (!context.msg.getAttachments().isEmpty()) {
             Attachment attachment = context.msg.getAttachments().get(0);
             imageUrl = attachment.getUrl();
-        } else if (context.args.length > 0) {
+        } else if (context.hasArguments()) {
             imageUrl = context.args[0];
         }
 

--- a/FredBoat/src/main/java/fredboat/command/admin/SetAvatarCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/SetAvatarCommand.java
@@ -31,8 +31,8 @@ public class SetAvatarCommand extends Command implements ICommandRestricted {
         if (!context.msg.getAttachments().isEmpty()) {
             Attachment attachment = context.msg.getAttachments().get(0);
             imageUrl = attachment.getUrl();
-        } else if (context.args.length > 1) {
-            imageUrl = context.args[1];
+        } else if (context.args.length > 0) {
+            imageUrl = context.args[0];
         }
 
         if (imageUrl != null && (imageUrl.startsWith("http://") || imageUrl.startsWith("https://"))) {

--- a/FredBoat/src/main/java/fredboat/command/admin/TestCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/TestCommand.java
@@ -63,9 +63,9 @@ public class TestCommand extends Command implements ICommandRestricted {
 
         int t = 20;
         int o = 2000;
-        if (args.length > 2) {
-            t = Integer.valueOf(args[1]);
-            o = Integer.valueOf(args[2]);
+        if (args.length > 1) {
+            t = Integer.valueOf(args[0]);
+            o = Integer.valueOf(args[1]);
         }
         final int threads = t;
         final int operations = o;

--- a/FredBoat/src/main/java/fredboat/command/admin/UnblacklistCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/admin/UnblacklistCommand.java
@@ -49,12 +49,12 @@ public class UnblacklistCommand extends Command implements ICommandRestricted {
             return;
         }
 
-        if (context.msg.getMentionedUsers().isEmpty()) {
+        if (context.getMentionedUsers().isEmpty()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
 
-        User user = context.msg.getMentionedUsers().get(0);
+        User user = context.getMentionedUsers().get(0);
         String userId = user.getId();
 
         if (userId == null || "".equals(userId)) {

--- a/FredBoat/src/main/java/fredboat/command/fun/HugCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/fun/HugCommand.java
@@ -27,7 +27,6 @@ package fredboat.command.fun;
 import fredboat.commandmeta.abs.CommandContext;
 import fredboat.commandmeta.abs.IFunCommand;
 import fredboat.messaging.internal.Context;
-import net.dv8tion.jda.core.entities.Message;
 
 import javax.annotation.Nonnull;
 
@@ -48,14 +47,13 @@ public class HugCommand extends RandomImageCommand implements IFunCommand {
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        Message msg = context.msg;
         String hugMessage = null;
-        if (msg.getMentionedUsers().size() > 0) {
-            if (msg.getMentionedUsers().get(0).getIdLong() == msg.getJDA().getSelfUser().getIdLong()) {
+        if (!context.getMentionedUsers().isEmpty()) {
+            if (context.getMentionedUsers().get(0).getIdLong() == context.guild.getJDA().getSelfUser().getIdLong()) {
                 hugMessage = context.i18n("hugBot");
             } else {
                 hugMessage = "_"
-                        + context.i18nFormat("hugSuccess", msg.getMentionedUsers().get(0).getAsMention())
+                        + context.i18nFormat("hugSuccess", context.getMentionedUsers().get(0).getAsMention())
                         + "_";
             }
         }

--- a/FredBoat/src/main/java/fredboat/command/fun/JokeCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/fun/JokeCommand.java
@@ -52,12 +52,11 @@ public class JokeCommand extends Command implements IFunCommand {
             }
             
             String joke = object.getJSONObject("value").getString("joke");
-            String remainder = context.msg.getContent().substring(context.args[0].length()).trim();
 
-            if (context.msg.getMentionedUsers().size() > 0) {
-                joke = joke.replaceAll("Chuck Norris", context.msg.getMentionedUsers().get(0).getAsMention());
-            } else if (remainder.length() > 0){
-                joke = joke.replaceAll("Chuck Norris", remainder);
+            if (!context.getMentionedUsers().isEmpty()) {
+                joke = joke.replaceAll("Chuck Norris", context.getMentionedUsers().get(0).getAsMention());
+            } else if (!context.rawArgs.isEmpty()) {
+                joke = joke.replaceAll("Chuck Norris", context.rawArgs);
             }
             
             joke = joke.replaceAll("&quot;", "\"");

--- a/FredBoat/src/main/java/fredboat/command/fun/JokeCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/fun/JokeCommand.java
@@ -55,7 +55,7 @@ public class JokeCommand extends Command implements IFunCommand {
 
             if (!context.getMentionedUsers().isEmpty()) {
                 joke = joke.replaceAll("Chuck Norris", context.getMentionedUsers().get(0).getAsMention());
-            } else if (!context.rawArgs.isEmpty()) {
+            } else if (context.hasArguments()) {
                 joke = joke.replaceAll("Chuck Norris", context.rawArgs);
             }
             

--- a/FredBoat/src/main/java/fredboat/command/fun/PatCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/fun/PatCommand.java
@@ -28,7 +28,6 @@ package fredboat.command.fun;
 import fredboat.commandmeta.abs.CommandContext;
 import fredboat.commandmeta.abs.IFunCommand;
 import fredboat.messaging.internal.Context;
-import net.dv8tion.jda.core.entities.Message;
 
 import javax.annotation.Nonnull;
 
@@ -44,14 +43,13 @@ public class PatCommand extends RandomImageCommand implements IFunCommand {
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        Message msg = context.msg;
         String patMessage = null;
-        if (msg.getMentionedUsers().size() > 0) {
-            if (msg.getMentionedUsers().get(0).getIdLong() == msg.getJDA().getSelfUser().getIdLong()) {
+        if (!context.getMentionedUsers().isEmpty()) {
+            if (context.getMentionedUsers().get(0).getIdLong() == context.msg.getJDA().getSelfUser().getIdLong()) {
                 patMessage = context.i18n("patBot");
             } else {
                 patMessage = "_"
-                        + context.i18nFormat("patSuccess", msg.getMentionedUsers().get(0).getAsMention())
+                        + context.i18nFormat("patSuccess", context.getMentionedUsers().get(0).getAsMention())
                         + "_";
             }
         }

--- a/FredBoat/src/main/java/fredboat/command/fun/RiotCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/fun/RiotCommand.java
@@ -36,7 +36,7 @@ public class RiotCommand extends Command implements IFunCommand {
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        context.reply("ヽ༼ຈل͜ຈ༽ﾉ **" + context.msg.getContent().replaceFirst("\\S*\\s+", "").toUpperCase() + "** ヽ༼ຈل͜ຈ༽ﾉ");
+        context.reply("ヽ༼ຈل͜ຈ༽ﾉ **" + context.rawArgs.toUpperCase() + "** ヽ༼ຈل͜ຈ༽ﾉ"); //todo escape markdown
     }
 
     @Nonnull

--- a/FredBoat/src/main/java/fredboat/command/maintenance/DebugCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/maintenance/DebugCommand.java
@@ -29,7 +29,6 @@ import fredboat.FredBoat;
 import fredboat.audio.player.AudioLossCounter;
 import fredboat.audio.player.GuildPlayer;
 import fredboat.audio.player.PlayerRegistry;
-import fredboat.command.util.HelpCommand;
 import fredboat.commandmeta.abs.Command;
 import fredboat.commandmeta.abs.CommandContext;
 import fredboat.commandmeta.abs.ICommandRestricted;
@@ -55,29 +54,24 @@ public class DebugCommand extends Command implements IMaintenanceCommand, IComma
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
 
-        if (context.args.length == 1 || context.args.length == 2) {
-
-            Guild guild;
-            if (context.args.length == 1) {
-                guild = context.guild;
-            } else {
-                try {
-                    if (!PermsUtil.checkPermsWithFeedback(PermissionLevel.BOT_ADMIN, context)) {
-                        return;
-                    }
-                    guild = FredBoat.getGuildById(Long.parseLong(context.args[1]));
-                } catch (NumberFormatException ignored) {
-                    guild = null;
-                }
-            }
-
-            if (guild != null) {
-                context.reply(getDebugEmbed(PlayerRegistry.getOrCreate(guild)).build());
-            } else {
-                context.replyWithName(String.format("There is no guild with id `%s`.", context.args[1]));
-            }
+        Guild guild;
+        if (context.args.length == 0) {
+            guild = context.guild;
         } else {
-            HelpCommand.sendFormattedCommandHelp(context);
+            try {
+                if (!PermsUtil.checkPermsWithFeedback(PermissionLevel.BOT_ADMIN, context)) {
+                    return;
+                }
+                guild = FredBoat.getGuildById(Long.parseLong(context.args[0]));
+            } catch (NumberFormatException ignored) {
+                guild = null;
+            }
+        }
+
+        if (guild != null) {
+            context.reply(getDebugEmbed(PlayerRegistry.getOrCreate(guild)).build());
+        } else {
+            context.replyWithName(String.format("There is no guild with id `%s`.", context.args[0]));
         }
     }
 

--- a/FredBoat/src/main/java/fredboat/command/maintenance/DebugCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/maintenance/DebugCommand.java
@@ -55,7 +55,7 @@ public class DebugCommand extends Command implements IMaintenanceCommand, IComma
     public void onInvoke(@Nonnull CommandContext context) {
 
         Guild guild;
-        if (context.args.length == 0) {
+        if (!context.hasArguments()) {
             guild = context.guild;
         } else {
             try {

--- a/FredBoat/src/main/java/fredboat/command/maintenance/FuzzyUserSearchCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/maintenance/FuzzyUserSearchCommand.java
@@ -42,10 +42,11 @@ public class FuzzyUserSearchCommand extends Command implements IMaintenanceComma
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        if (context.args.length == 1) {
+        if (context.rawArgs.isEmpty()) {
             HelpCommand.sendFormattedCommandHelp(context);
         } else {
-            List<Member> list = ArgumentUtil.fuzzyMemberSearch(context.guild, context.args[1], true);
+            String query = context.rawArgs;
+            List<Member> list = ArgumentUtil.fuzzyMemberSearch(context.guild, query, true);
 
             if(list.isEmpty()){
                 context.replyWithName(context.i18n("fuzzyNoResults"));
@@ -78,14 +79,14 @@ public class FuzzyUserSearchCommand extends Command implements IMaintenanceComma
                     + TextUtils.padWithSpaces("Nick", nickPadding + 1, false) + "\n");
 
             for (String line : lines) {
-                if (sb.length() + line.length() < 1900) { //respect max message size
+                if (sb.length() + line.length() + query.length() < 1900) { //respect max message size
                     sb.append(line);
                 } else {
                     sb.append("[...]");
                     break;
                 }
             }
-            context.replyWithName(TextUtils.asCodeBlock(sb.toString()));
+            context.replyWithName("Results for `" + query + "`: " + TextUtils.asCodeBlock(sb.toString()));
         }
     }
 

--- a/FredBoat/src/main/java/fredboat/command/maintenance/FuzzyUserSearchCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/maintenance/FuzzyUserSearchCommand.java
@@ -42,7 +42,7 @@ public class FuzzyUserSearchCommand extends Command implements IMaintenanceComma
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        if (context.rawArgs.isEmpty()) {
+        if (!context.hasArguments()) {
             HelpCommand.sendFormattedCommandHelp(context);
         } else {
             String query = context.rawArgs;

--- a/FredBoat/src/main/java/fredboat/command/maintenance/NodesCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/maintenance/NodesCommand.java
@@ -60,7 +60,7 @@ public class NodesCommand extends Command implements IMaintenanceCommand {
     @SuppressWarnings("StringConcatenationInLoop")
     private void handleLavalink(CommandContext context) {
         Lavalink lavalink = LavalinkManager.ins.getLavalink();
-        if (context.args.length >= 1 && !context.args[0].equals("host")) {
+        if (context.hasArguments() && !context.args[0].equals("host")) {
             try {
                 LavalinkSocket socket = lavalink.getNodes().get(Integer.parseInt(context.args[0]));
                 context.reply(TextUtils.asCodeBlock(socket.getStats().getAsJson().toString(4), "json"));
@@ -71,7 +71,7 @@ public class NodesCommand extends Command implements IMaintenanceCommand {
         }
 
         boolean showHosts = false;
-        if (context.args.length >= 1 && context.args[0].equals("host")) {
+        if (context.hasArguments() && context.args[0].equals("host")) {
             if (PermsUtil.checkPermsWithFeedback(PermissionLevel.BOT_ADMIN, context)) {
                 showHosts = true;
             } else {
@@ -136,7 +136,7 @@ public class NodesCommand extends Command implements IMaintenanceCommand {
         List<RemoteNode> nodes = pm.getRemoteNodeRegistry().getNodes();
         boolean showHost = false;
 
-        if (context.args.length == 1 && context.args[0].equals("host")) {
+        if (context.hasArguments() && context.args[0].equals("host")) {
             if (PermsUtil.checkPerms(PermissionLevel.BOT_OWNER, context.invoker)) {
                 showHost = true;
             } else {

--- a/FredBoat/src/main/java/fredboat/command/maintenance/NodesCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/maintenance/NodesCommand.java
@@ -60,18 +60,18 @@ public class NodesCommand extends Command implements IMaintenanceCommand {
     @SuppressWarnings("StringConcatenationInLoop")
     private void handleLavalink(CommandContext context) {
         Lavalink lavalink = LavalinkManager.ins.getLavalink();
-        if (context.args.length >= 2 && !context.args[1].equals("host")) {
+        if (context.args.length >= 1 && !context.args[0].equals("host")) {
             try {
-                LavalinkSocket socket = lavalink.getNodes().get(Integer.parseInt(context.args[1]));
+                LavalinkSocket socket = lavalink.getNodes().get(Integer.parseInt(context.args[0]));
                 context.reply(TextUtils.asCodeBlock(socket.getStats().getAsJson().toString(4), "json"));
                 return;
             } catch (NumberFormatException | IndexOutOfBoundsException ignored) { //fallthrough
-                context.replyWithName(String.format("No such node: `%s`, showing all nodes instead.", context.args[1]));
+                context.replyWithName(String.format("No such node: `%s`, showing all nodes instead.", context.args[0]));
             }
         }
 
         boolean showHosts = false;
-        if (context.args.length >= 2 && context.args[1].equals("host")) {
+        if (context.args.length >= 1 && context.args[0].equals("host")) {
             if (PermsUtil.checkPermsWithFeedback(PermissionLevel.BOT_ADMIN, context)) {
                 showHosts = true;
             } else {
@@ -136,7 +136,7 @@ public class NodesCommand extends Command implements IMaintenanceCommand {
         List<RemoteNode> nodes = pm.getRemoteNodeRegistry().getNodes();
         boolean showHost = false;
 
-        if (context.args.length == 2 && context.args[1].equals("host")) {
+        if (context.args.length == 1 && context.args[0].equals("host")) {
             if (PermsUtil.checkPerms(PermissionLevel.BOT_OWNER, context.invoker)) {
                 showHost = true;
             } else {

--- a/FredBoat/src/main/java/fredboat/command/moderation/ConfigCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/ConfigCommand.java
@@ -46,7 +46,7 @@ public class ConfigCommand extends Command implements IModerationCommand, IComma
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        if (context.args.length == 1) {
+        if (context.args.length == 0) {
             printConfig(context);
         } else {
             setConfig(context);
@@ -66,20 +66,19 @@ public class ConfigCommand extends Command implements IModerationCommand, IComma
     }
 
     private void setConfig(CommandContext context) {
-        String[] args = context.args;
         Member invoker = context.invoker;
         if (!PermsUtil.checkPermsWithFeedback(PermissionLevel.ADMIN, context)) {
             return;
         }
 
-        if(args.length != 3) {
+        if (context.args.length != 2) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
 
         GuildConfig gc = EntityReader.getGuildConfig(context.guild.getId());
-        String key = args[1];
-        String val = args[2];
+        String key = context.args[0];
+        String val = context.args[1];
 
         switch (key) {
             case "track_announce":

--- a/FredBoat/src/main/java/fredboat/command/moderation/ConfigCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/ConfigCommand.java
@@ -46,7 +46,7 @@ public class ConfigCommand extends Command implements IModerationCommand, IComma
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        if (context.args.length == 0) {
+        if (!context.hasArguments()) {
             printConfig(context);
         } else {
             setConfig(context);

--- a/FredBoat/src/main/java/fredboat/command/moderation/DisableCommandsCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/DisableCommandsCommand.java
@@ -15,28 +15,26 @@ public class DisableCommandsCommand extends Command implements ICommandRestricte
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
 
-        if (context.args.length  == 2) {
-            try {
-                CommandRegistry.CommandEntry commandEntry = CommandRegistry.getCommand(context.args[1]);
-
-                if (commandEntry.name.equals("enable")
-                        || commandEntry.name.equals("disable")) {
-                    context.reply("Let's not disable this :wink:");
-                    return;
-                }
-
-                if (CommandManager.disabledCommands.contains(commandEntry.command)) {
-                    context.reply("This command is already disabled!");
-                    return;
-                }
-
-                CommandManager.disabledCommands.add(commandEntry.command);
-                context.reply(":ok_hand: Command `" + commandEntry.name + "` disabled!");
-
-            } catch (NullPointerException ex) {
+        if (context.args.length == 1) {
+            CommandRegistry.CommandEntry commandEntry = CommandRegistry.getCommand(context.args[0]);
+            if (commandEntry == null) {
                 context.reply("This command doesn't exist!");
+                return;
             }
 
+            if (commandEntry.name.equals("enable")
+                    || commandEntry.name.equals("disable")) {
+                context.reply("Let's not disable this :wink:");
+                return;
+            }
+
+            if (CommandManager.disabledCommands.contains(commandEntry.command)) {
+                context.reply("This command is already disabled!");
+                return;
+            }
+
+            CommandManager.disabledCommands.add(commandEntry.command);
+            context.reply(":ok_hand: Command `" + commandEntry.name + "` disabled!");
         } else {
             HelpCommand.sendFormattedCommandHelp(context);
         }

--- a/FredBoat/src/main/java/fredboat/command/moderation/DisableCommandsCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/DisableCommandsCommand.java
@@ -15,7 +15,7 @@ public class DisableCommandsCommand extends Command implements ICommandRestricte
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
 
-        if (context.args.length == 1) {
+        if (context.hasArguments()) {
             CommandRegistry.CommandEntry commandEntry = CommandRegistry.getCommand(context.args[0]);
             if (commandEntry == null) {
                 context.reply("This command doesn't exist!");

--- a/FredBoat/src/main/java/fredboat/command/moderation/EnableCommandsCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/EnableCommandsCommand.java
@@ -15,7 +15,7 @@ public class EnableCommandsCommand extends Command implements ICommandRestricted
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
 
-        if (context.args.length == 1) {
+        if (context.hasArguments()) {
             CommandRegistry.CommandEntry commandEntry = CommandRegistry.getCommand(context.args[0]);
             if (commandEntry == null) {
                 context.reply("This command doesn't exist!");

--- a/FredBoat/src/main/java/fredboat/command/moderation/EnableCommandsCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/EnableCommandsCommand.java
@@ -15,21 +15,19 @@ public class EnableCommandsCommand extends Command implements ICommandRestricted
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
 
-        if (context.args.length  == 2) {
-            try {
-                CommandRegistry.CommandEntry commandEntry = CommandRegistry.getCommand(context.args[1]);
-
-                if (CommandManager.disabledCommands.contains(commandEntry.command)) {
-                    CommandManager.disabledCommands.remove(commandEntry.command);
-                    context.reply(":ok_hand: Command `" + commandEntry.name + "` enabled!");
-                    return;
-                }
-                context.reply("This command is not disabled!");
-
-            } catch (NullPointerException ex) {
+        if (context.args.length == 1) {
+            CommandRegistry.CommandEntry commandEntry = CommandRegistry.getCommand(context.args[0]);
+            if (commandEntry == null) {
                 context.reply("This command doesn't exist!");
+                return;
             }
 
+            if (CommandManager.disabledCommands.contains(commandEntry.command)) {
+                CommandManager.disabledCommands.remove(commandEntry.command);
+                context.reply(":ok_hand: Command `" + commandEntry.name + "` enabled!");
+                return;
+            }
+            context.reply("This command is not disabled!");
         } else {
             HelpCommand.sendFormattedCommandHelp(context);
         }

--- a/FredBoat/src/main/java/fredboat/command/moderation/HardbanCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/HardbanCommand.java
@@ -56,7 +56,7 @@ public class HardbanCommand extends Command implements IModerationCommand {
     public void onInvoke(@Nonnull CommandContext context) {
         Guild guild = context.guild;
         //Ensure we have a search term
-        if (context.args.length < 1) {
+        if (!context.hasArguments()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }

--- a/FredBoat/src/main/java/fredboat/command/moderation/HardbanCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/HardbanCommand.java
@@ -54,16 +54,15 @@ public class HardbanCommand extends Command implements IModerationCommand {
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        String[] args = context.args;
         Guild guild = context.guild;
         //Ensure we have a search term
-        if (args.length == 1) {
+        if (context.args.length < 1) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
 
         //was there a target provided?
-        Member target = ArgumentUtil.checkSingleFuzzyMemberSearchResult(context, args[1]);
+        Member target = ArgumentUtil.checkSingleFuzzyMemberSearchResult(context, context.args[0]);
         if (target == null) return;
 
         //are we allowed to do that?

--- a/FredBoat/src/main/java/fredboat/command/moderation/KickCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/KickCommand.java
@@ -54,16 +54,15 @@ public class KickCommand extends Command implements IModerationCommand {
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        String[] args = context.args;
         Guild guild = context.guild;
         //Ensure we have a search term
-        if (args.length == 1) {
+        if (context.args.length < 1) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
 
         //was there a target provided?
-        Member target = ArgumentUtil.checkSingleFuzzyMemberSearchResult(context, args[1]);
+        Member target = ArgumentUtil.checkSingleFuzzyMemberSearchResult(context, context.args[0]);
         if (target == null) return;
 
         //are we allowed to do that?

--- a/FredBoat/src/main/java/fredboat/command/moderation/KickCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/KickCommand.java
@@ -56,7 +56,7 @@ public class KickCommand extends Command implements IModerationCommand {
     public void onInvoke(@Nonnull CommandContext context) {
         Guild guild = context.guild;
         //Ensure we have a search term
-        if (context.args.length < 1) {
+        if (!context.hasArguments()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }

--- a/FredBoat/src/main/java/fredboat/command/moderation/LanguageCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/LanguageCommand.java
@@ -47,7 +47,7 @@ public class LanguageCommand extends Command implements IModerationCommand {
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
         Guild guild = context.guild;
-        if (context.args.length < 1) {
+        if (!context.hasArguments()) {
             handleNoArgs(context);
             return;
         }

--- a/FredBoat/src/main/java/fredboat/command/moderation/LanguageCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/LanguageCommand.java
@@ -46,9 +46,8 @@ public class LanguageCommand extends Command implements IModerationCommand {
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        String[] args = context.args;
         Guild guild = context.guild;
-        if(args.length != 2) {
+        if (context.args.length < 1) {
             handleNoArgs(context);
             return;
         }
@@ -58,9 +57,9 @@ public class LanguageCommand extends Command implements IModerationCommand {
         
         //Assume proper usage and that we are about to set a new language
         try {
-            I18n.set(guild, args[1]);
+            I18n.set(guild, context.args[0]);
         } catch (I18n.LanguageNotSupportedException e) {
-            context.replyWithName(context.i18nFormat("langInvalidCode", args[1]));
+            context.replyWithName(context.i18nFormat("langInvalidCode", context.args[0]));
             return;
         }
 
@@ -69,7 +68,7 @@ public class LanguageCommand extends Command implements IModerationCommand {
 
     private void handleNoArgs(CommandContext context) {
         MessageBuilder mb = CentralMessaging.getClearThreadLocalMessageBuilder()
-                .append(context.i18n("langInfo").replace(Config.DEFAULT_PREFIX, Config.CONFIG.getPrefix()))
+                .append(context.i18n("langInfo").replace(Config.DEFAULT_PREFIX, Config.CONFIG.getPrefix()))//todo custom prefix
                 .append("\n\n");
 
         List<String> keys = new ArrayList<>(I18n.LANGS.keySet());

--- a/FredBoat/src/main/java/fredboat/command/moderation/PermissionsCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/PermissionsCommand.java
@@ -69,13 +69,12 @@ public class PermissionsCommand extends Command implements IModerationCommand {
             context.reply("Permissions are currently disabled.");
             return;
         }
-        String[] args = context.args;
-        if (args.length < 2) {
+        if (context.args.length < 1) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
 
-        switch (args[1]) {
+        switch (context.args[0]) {
             case "del":
             case "delete":
             case "remove":
@@ -83,7 +82,7 @@ public class PermissionsCommand extends Command implements IModerationCommand {
             case "rm":
                 if (!PermsUtil.checkPermsWithFeedback(PermissionLevel.ADMIN, context)) return;
 
-                if (args.length < 3) {
+                if (context.args.length < 2) {
                     HelpCommand.sendFormattedCommandHelp(context);
                     return;
                 }
@@ -93,7 +92,7 @@ public class PermissionsCommand extends Command implements IModerationCommand {
             case "add":
                 if (!PermsUtil.checkPermsWithFeedback(PermissionLevel.ADMIN, context)) return;
 
-                if (args.length < 3) {
+                if (context.args.length < 2) {
                     HelpCommand.sendFormattedCommandHelp(context);
                     return;
                 }
@@ -113,7 +112,8 @@ public class PermissionsCommand extends Command implements IModerationCommand {
     public void remove(CommandContext context) {
         Guild guild = context.guild;
         Member invoker = context.invoker;
-        String term = ArgumentUtil.getSearchTerm(context.msg, context.args, 2);
+        //remove the first argument aka add / remove etc to get a nice search term
+        String term = context.rawArgs.replaceFirst(context.args[0], "").trim();
 
         List<IMentionable> search = new ArrayList<>();
         search.addAll(ArgumentUtil.fuzzyRoleSearch(guild, term));
@@ -147,7 +147,8 @@ public class PermissionsCommand extends Command implements IModerationCommand {
 
     public void add(CommandContext context) {
         Guild guild = context.guild;
-        String term = ArgumentUtil.getSearchTerm(context.msg, context.args, 2);
+        //remove the first argument aka add / remove etc to get a nice search term
+        String term = context.rawArgs.replaceFirst(context.args[0], "").trim();
 
         List<IMentionable> list = new ArrayList<>();
         list.addAll(ArgumentUtil.fuzzyRoleSearch(guild, term));

--- a/FredBoat/src/main/java/fredboat/command/moderation/PermissionsCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/PermissionsCommand.java
@@ -69,7 +69,7 @@ public class PermissionsCommand extends Command implements IModerationCommand {
             context.reply("Permissions are currently disabled.");
             return;
         }
-        if (context.args.length < 1) {
+        if (!context.hasArguments()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }

--- a/FredBoat/src/main/java/fredboat/command/moderation/SoftbanCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/SoftbanCommand.java
@@ -50,7 +50,7 @@ public class SoftbanCommand extends Command implements IModerationCommand {
     public void onInvoke(@Nonnull CommandContext context) {
         Guild guild = context.guild;
         //Ensure we have a search term
-        if (context.args.length < 1) {
+        if (!context.hasArguments()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }

--- a/FredBoat/src/main/java/fredboat/command/moderation/SoftbanCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/moderation/SoftbanCommand.java
@@ -48,16 +48,15 @@ public class SoftbanCommand extends Command implements IModerationCommand {
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        String[] args = context.args;
         Guild guild = context.guild;
         //Ensure we have a search term
-        if (args.length == 1) {
+        if (context.args.length < 1) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
 
         //was there a target provided?
-        Member target = ArgumentUtil.checkSingleFuzzyMemberSearchResult(context, args[1]);
+        Member target = ArgumentUtil.checkSingleFuzzyMemberSearchResult(context, context.args[0]);
         if (target == null) return;
 
         //are we allowed to do that?

--- a/FredBoat/src/main/java/fredboat/command/music/control/PlayCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/PlayCommand.java
@@ -82,7 +82,7 @@ public class PlayCommand extends Command implements IMusicCommand, ICommandRestr
             return;
         }
 
-        if (context.args.length < 1) {
+        if (!context.hasArguments()) {
             handleNoArguments(context);
             return;
         }

--- a/FredBoat/src/main/java/fredboat/command/music/control/PlaySplitCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/PlaySplitCommand.java
@@ -45,7 +45,7 @@ public class PlaySplitCommand extends Command implements IMusicCommand, ICommand
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
 
-        if (context.args.length < 1) {
+        if (!context.hasArguments()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }

--- a/FredBoat/src/main/java/fredboat/command/music/control/PlaySplitCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/PlaySplitCommand.java
@@ -45,14 +45,14 @@ public class PlaySplitCommand extends Command implements IMusicCommand, ICommand
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
 
-        if (context.args.length < 2) {
+        if (context.args.length < 1) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
 
         if (!PlayerLimitManager.checkLimitResponsive(context)) return;
 
-        IdentifierContext ic = new IdentifierContext(context.args[1], context.channel, context.invoker);
+        IdentifierContext ic = new IdentifierContext(context.args[0], context.channel, context.invoker);
         ic.setSplit(true);
 
         GuildPlayer player = PlayerRegistry.getOrCreate(context.guild);

--- a/FredBoat/src/main/java/fredboat/command/music/control/RepeatCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/RepeatCommand.java
@@ -44,7 +44,7 @@ public class RepeatCommand extends Command implements IMusicCommand, ICommandRes
     public void onInvoke(@Nonnull CommandContext context) {
         GuildPlayer player = PlayerRegistry.getOrCreate(context.guild);
 
-        if (context.args.length < 1) {
+        if (!context.hasArguments()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }

--- a/FredBoat/src/main/java/fredboat/command/music/control/RepeatCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/RepeatCommand.java
@@ -44,13 +44,13 @@ public class RepeatCommand extends Command implements IMusicCommand, ICommandRes
     public void onInvoke(@Nonnull CommandContext context) {
         GuildPlayer player = PlayerRegistry.getOrCreate(context.guild);
 
-        if (context.args.length < 2) {
+        if (context.args.length < 1) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
 
         RepeatMode desiredRepeatMode;
-        String userInput = context.args[1];
+        String userInput = context.args[0];
         switch (userInput) {
             case "off":
             case "out":

--- a/FredBoat/src/main/java/fredboat/command/music/control/SkipCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/SkipCommand.java
@@ -75,11 +75,11 @@ public class SkipCommand extends Command implements IMusicCommand, ICommandRestr
             guildIdToLastSkip.put(context.guild.getId(), System.currentTimeMillis());
         }
 
-        if (context.args.length == 0) {
+        if (!context.hasArguments()) {
             skipNext(context);
-        } else if (context.args.length == 1 && StringUtils.isNumeric(context.args[0])) {
+        } else if (context.hasArguments() && StringUtils.isNumeric(context.args[0])) {
             skipGivenIndex(player, context);
-        } else if (context.args.length == 1 && trackRangePattern.matcher(context.args[0]).matches()) {
+        } else if (context.hasArguments() && trackRangePattern.matcher(context.args[0]).matches()) {
             skipInRange(player, context);
         } else if (!context.getMentionedUsers().isEmpty()) {
             skipUser(player, context, context.getMentionedUsers());

--- a/FredBoat/src/main/java/fredboat/command/music/control/SkipCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/SkipCommand.java
@@ -75,15 +75,14 @@ public class SkipCommand extends Command implements IMusicCommand, ICommandRestr
             guildIdToLastSkip.put(context.guild.getId(), System.currentTimeMillis());
         }
 
-        String[] args = context.args;
-        if (args.length == 1) {
+        if (context.args.length == 0) {
             skipNext(context);
-        } else if (args.length == 2 && StringUtils.isNumeric(args[1])) {
+        } else if (context.args.length == 1 && StringUtils.isNumeric(context.args[0])) {
             skipGivenIndex(player, context);
-        } else if (args.length == 2 && trackRangePattern.matcher(args[1]).matches()) {
+        } else if (context.args.length == 1 && trackRangePattern.matcher(context.args[0]).matches()) {
             skipInRange(player, context);
-        } else if (args.length >= 2 && context.msg.getMentionedUsers().size() > 0) {
-            skipUser(player, context, context.msg.getMentionedUsers());
+        } else if (!context.getMentionedUsers().isEmpty()) {
+            skipUser(player, context, context.getMentionedUsers());
         } else {
             HelpCommand.sendFormattedCommandHelp(context);
         }
@@ -104,9 +103,9 @@ public class SkipCommand extends Command implements IMusicCommand, ICommandRestr
     private void skipGivenIndex(GuildPlayer player, CommandContext context) {
         int givenIndex;
         try {
-            givenIndex = Integer.parseInt(context.args[1]);
+            givenIndex = Integer.parseInt(context.args[0]);
         } catch (NumberFormatException e) {
-            context.reply(context.i18nFormat("skipOutOfBounds", context.args[1], player.getTrackCount()));
+            context.reply(context.i18nFormat("skipOutOfBounds", context.args[0], player.getTrackCount()));
             return;
         }
 
@@ -130,7 +129,7 @@ public class SkipCommand extends Command implements IMusicCommand, ICommandRestr
     }
 
     private void skipInRange(GuildPlayer player, CommandContext context) {
-        Matcher trackMatch = trackRangePattern.matcher(context.args[1]);
+        Matcher trackMatch = trackRangePattern.matcher(context.args[0]);
         if (!trackMatch.find()) return;
 
         int startTrackIndex;

--- a/FredBoat/src/main/java/fredboat/command/music/control/VolumeCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/VolumeCommand.java
@@ -48,7 +48,7 @@ public class VolumeCommand extends Command implements IMusicCommand, ICommandRes
 
             GuildPlayer player = PlayerRegistry.getOrCreate(context.guild);
             try {
-                float volume = Float.parseFloat(context.args[1]) / 100;
+                float volume = Float.parseFloat(context.args[0]) / 100;
                 volume = Math.max(0, Math.min(1.5f, volume));
 
                 context.reply(context.i18nFormat("volumeSuccess",

--- a/FredBoat/src/main/java/fredboat/command/music/control/VoteSkipCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/VoteSkipCommand.java
@@ -55,7 +55,7 @@ public class VoteSkipCommand extends Command implements IMusicCommand, ICommandR
             guildIdToLastSkip.put(context.guild.getId(), System.currentTimeMillis());
         }
 
-        if (context.args.length == 0) {
+        if (!context.hasArguments()) {
             String response = addVoteWithResponse(context);
             float actualMinSkip = player.getHumanUsersInCurrentVC().size() < 3 ? 1.0f : MIN_SKIP_PERCENTAGE;
 
@@ -77,7 +77,7 @@ public class VoteSkipCommand extends Command implements IMusicCommand, ICommandR
                 context.reply(response + "\n" + context.i18nFormat("voteSkipNotEnough", skipPerc, minSkipPerc));
             }
 
-        } else if (context.args.length == 1 && context.args[0].toLowerCase().equals("list")) {
+        } else if (context.args[0].toLowerCase().equals("list")) {
             displayVoteList(context, player);
         } else {
             HelpCommand.sendFormattedCommandHelp(context);

--- a/FredBoat/src/main/java/fredboat/command/music/control/VoteSkipCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/VoteSkipCommand.java
@@ -55,7 +55,7 @@ public class VoteSkipCommand extends Command implements IMusicCommand, ICommandR
             guildIdToLastSkip.put(context.guild.getId(), System.currentTimeMillis());
         }
 
-        if (context.args.length == 1) {
+        if (context.args.length == 0) {
             String response = addVoteWithResponse(context);
             float actualMinSkip = player.getHumanUsersInCurrentVC().size() < 3 ? 1.0f : MIN_SKIP_PERCENTAGE;
 
@@ -77,7 +77,7 @@ public class VoteSkipCommand extends Command implements IMusicCommand, ICommandR
                 context.reply(response + "\n" + context.i18nFormat("voteSkipNotEnough", skipPerc, minSkipPerc));
             }
 
-        } else if (context.args.length == 2 && context.args[1].toLowerCase().equals("list")) {
+        } else if (context.args.length == 1 && context.args[0].toLowerCase().equals("list")) {
             displayVoteList(context, player);
         } else {
             HelpCommand.sendFormattedCommandHelp(context);

--- a/FredBoat/src/main/java/fredboat/command/music/info/HistoryCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/info/HistoryCommand.java
@@ -36,7 +36,6 @@ import fredboat.messaging.internal.Context;
 import fredboat.util.TextUtils;
 import net.dv8tion.jda.core.MessageBuilder;
 import net.dv8tion.jda.core.entities.Member;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.text.MessageFormat;
@@ -44,16 +43,11 @@ import java.util.List;
 
 public class HistoryCommand extends Command implements IMusicCommand {
 
-  private static final org.slf4j.Logger log = LoggerFactory.getLogger(HistoryCommand.class);
-
   private static final int PAGE_SIZE = 10;
 
   @Override
-  public void onInvoke(CommandContext context) {
+  public void onInvoke(@Nonnull CommandContext context) {
       GuildPlayer player = PlayerRegistry.getOrCreate(context.guild);
-      player.setCurrentTC(context.channel);
-
-      MessageBuilder mb = CentralMessaging.getClearThreadLocalMessageBuilder();
 
       if (player.isHistoryQueueEmpty()) {
           context.reply(context.i18n("npNotInHistory"));
@@ -61,9 +55,9 @@ public class HistoryCommand extends Command implements IMusicCommand {
       }
 
       int page = 1;
-      if (context.args.length >= 2) {
+      if (context.hasArguments()) {
           try {
-              page = Integer.valueOf(context.args[1]);
+              page = Integer.valueOf(context.args[0]);
           } catch (NumberFormatException e) {
               page = 1;
           }
@@ -83,12 +77,12 @@ public class HistoryCommand extends Command implements IMusicCommand {
 
       List<AudioTrackContext> sublist = player.getTracksInHistory(i, listEnd);
 
-      mb.append(context.i18n("listShowHistory"));
-      mb.append("\n");
-
-      mb.append(MessageFormat.format(context.i18n("listPageNum"), page, maxPages));
-      mb.append("\n");
-      mb.append("\n");
+      MessageBuilder mb = CentralMessaging.getClearThreadLocalMessageBuilder()
+              .append(context.i18n("listShowHistory"))
+              .append("\n")
+              .append(MessageFormat.format(context.i18n("listPageNum"), page, maxPages))
+              .append("\n")
+              .append("\n");
 
       for (AudioTrackContext atc: sublist) {
           String status = " ";
@@ -112,6 +106,7 @@ public class HistoryCommand extends Command implements IMusicCommand {
       context.reply(mb.build());
   }
 
+  @Nonnull
   @Override
   public String help(@Nonnull Context context) {
       String usage = "{0}{1}\n#";

--- a/FredBoat/src/main/java/fredboat/command/music/info/ListCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/info/ListCommand.java
@@ -60,7 +60,7 @@ public class ListCommand extends Command implements IMusicCommand {
         MessageBuilder mb = CentralMessaging.getClearThreadLocalMessageBuilder();
 
         int page = 1;
-        if (context.args.length > 0) {
+        if (context.hasArguments()) {
             try {
                 page = Integer.valueOf(context.args[0]);
             } catch (NumberFormatException e) {

--- a/FredBoat/src/main/java/fredboat/command/music/info/ListCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/info/ListCommand.java
@@ -60,9 +60,9 @@ public class ListCommand extends Command implements IMusicCommand {
         MessageBuilder mb = CentralMessaging.getClearThreadLocalMessageBuilder();
 
         int page = 1;
-        if (context.args.length >= 2) {
+        if (context.args.length > 0) {
             try {
-                page = Integer.valueOf(context.args[1]);
+                page = Integer.valueOf(context.args[0]);
             } catch (NumberFormatException e) {
                 page = 1;
             }

--- a/FredBoat/src/main/java/fredboat/command/music/seeking/ForwardCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/seeking/ForwardCommand.java
@@ -51,14 +51,14 @@ public class ForwardCommand extends Command implements IMusicCommand, ICommandRe
             return;
         }
 
-        if (context.args.length == 1) {
+        if (context.args.length == 0) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
 
         long t;
         try {
-            t = TextUtils.parseTimeString(context.args[1]);
+            t = TextUtils.parseTimeString(context.args[0]);
         } catch (IllegalStateException e){
             HelpCommand.sendFormattedCommandHelp(context);
             return;

--- a/FredBoat/src/main/java/fredboat/command/music/seeking/ForwardCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/seeking/ForwardCommand.java
@@ -51,7 +51,7 @@ public class ForwardCommand extends Command implements IMusicCommand, ICommandRe
             return;
         }
 
-        if (context.args.length == 0) {
+        if (!context.hasArguments()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }

--- a/FredBoat/src/main/java/fredboat/command/music/seeking/RewindCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/seeking/RewindCommand.java
@@ -49,14 +49,14 @@ public class RewindCommand extends Command implements IMusicCommand, ICommandRes
             return;
         }
 
-        if (context.args.length == 1) {
+        if (context.args.length == 0) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
 
         long t;
         try {
-            t = TextUtils.parseTimeString(context.args[1]);
+            t = TextUtils.parseTimeString(context.args[0]);
         } catch (IllegalStateException e){
             HelpCommand.sendFormattedCommandHelp(context);
             return;

--- a/FredBoat/src/main/java/fredboat/command/music/seeking/RewindCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/seeking/RewindCommand.java
@@ -49,7 +49,7 @@ public class RewindCommand extends Command implements IMusicCommand, ICommandRes
             return;
         }
 
-        if (context.args.length == 0) {
+        if (!context.hasArguments()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }

--- a/FredBoat/src/main/java/fredboat/command/music/seeking/SeekCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/seeking/SeekCommand.java
@@ -50,14 +50,14 @@ public class SeekCommand extends Command implements IMusicCommand, ICommandRestr
             return;
         }
 
-        if (context.args.length == 1) {
+        if (context.args.length == 0) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
 
         long t;
         try {
-            t = TextUtils.parseTimeString(context.args[1]);
+            t = TextUtils.parseTimeString(context.args[0]);
         } catch (IllegalStateException e){
             HelpCommand.sendFormattedCommandHelp(context);
             return;

--- a/FredBoat/src/main/java/fredboat/command/music/seeking/SeekCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/seeking/SeekCommand.java
@@ -50,7 +50,7 @@ public class SeekCommand extends Command implements IMusicCommand, ICommandRestr
             return;
         }
 
-        if (context.args.length == 0) {
+        if (!context.hasArguments()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }

--- a/FredBoat/src/main/java/fredboat/command/util/AvatarCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/util/AvatarCommand.java
@@ -36,11 +36,11 @@ public class AvatarCommand extends Command implements IUtilCommand {
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        if (context.msg.getMentionedUsers().isEmpty()) {
+        if (context.getMentionedUsers().isEmpty()) {
             HelpCommand.sendFormattedCommandHelp(context);
         } else {
             context.replyWithName(context.i18nFormat("avatarSuccess",
-                    context.msg.getMentionedUsers().get(0).getAvatarUrl()));
+                    context.getMentionedUsers().get(0).getAvatarUrl()));
         }
     }
 

--- a/FredBoat/src/main/java/fredboat/command/util/BrainfuckCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/util/BrainfuckCommand.java
@@ -112,19 +112,18 @@ public class BrainfuckCommand extends Command implements IUtilCommand {
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
 
-        if (context.args.length == 1) {
+        if (context.args.length == 0) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
 
-        code = context.msg.getContent().replaceFirst(context.args[0], "").toCharArray();
+        code = context.rawArgs.toCharArray();
         bytes = ByteBuffer.allocateDirect(1024 * 1024 * 8);
         String inputArg = "";
 
         try {
-            inputArg = context.args[2];
-        } catch (Exception e) {
-
+            inputArg = context.args[1];
+        } catch (Exception ignored) {
         }
 
         inputArg = inputArg.replaceAll("ZERO", String.valueOf((char) 0));

--- a/FredBoat/src/main/java/fredboat/command/util/BrainfuckCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/util/BrainfuckCommand.java
@@ -112,7 +112,7 @@ public class BrainfuckCommand extends Command implements IUtilCommand {
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
 
-        if (context.args.length == 0) {
+        if (!context.hasArguments()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }

--- a/FredBoat/src/main/java/fredboat/command/util/HelpCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/util/HelpCommand.java
@@ -62,7 +62,7 @@ public class HelpCommand extends Command implements IUtilCommand {
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
 
-        if (context.args.length > 0) {
+        if (context.hasArguments()) {
             sendFormattedCommandHelp(context, context.args[0]);
         } else {
             sendGeneralHelp(context);

--- a/FredBoat/src/main/java/fredboat/command/util/HelpCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/util/HelpCommand.java
@@ -62,8 +62,8 @@ public class HelpCommand extends Command implements IUtilCommand {
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
 
-        if (context.args.length > 1) {
-            sendFormattedCommandHelp(context, context.args[1]);
+        if (context.args.length > 0) {
+            sendFormattedCommandHelp(context, context.args[0]);
         } else {
             sendGeneralHelp(context);
         }

--- a/FredBoat/src/main/java/fredboat/command/util/MALCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/util/MALCommand.java
@@ -58,7 +58,6 @@ import java.util.regex.Pattern;
 public class MALCommand extends Command implements IUtilCommand {
 
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(MALCommand.class);
-    private static Pattern regex = Pattern.compile("^\\S+\\s+([\\W\\w]*)");
 
     //MALs API is wonky af and loves to take its time to answer requests, so we are setting rather high time outs
     private static OkHttpClient malHttpClient = new OkHttpClient.Builder()
@@ -69,14 +68,12 @@ public class MALCommand extends Command implements IUtilCommand {
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        Matcher matcher = regex.matcher(context.msg.getContent());
-
-        if (!matcher.find()) {
+        if (context.rawArgs.isEmpty()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
 
-        String term = matcher.group(1).replace(' ', '+').trim();
+        String term = context.rawArgs.replace(' ', '+').trim();
         log.debug("TERM:" + term);
 
         FredBoat.executor.submit(() -> requestAsync(term, context));

--- a/FredBoat/src/main/java/fredboat/command/util/MALCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/util/MALCommand.java
@@ -68,7 +68,7 @@ public class MALCommand extends Command implements IUtilCommand {
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        if (context.rawArgs.isEmpty()) {
+        if (!context.hasArguments()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }

--- a/FredBoat/src/main/java/fredboat/command/util/MathCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/util/MathCommand.java
@@ -48,28 +48,27 @@ public class MathCommand extends Command implements IUtilCommand {
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        String[] args = context.args;
         String output;
 
         try {
-            if(args.length == 3) {
+            if (context.args.length == 2) {
 
-                BigDecimal num1 = new BigDecimal(args[2]);
+                BigDecimal num1 = new BigDecimal(context.args[1]);
 
-                if (args[1].equals("sqrt")) {
+                if (context.args[0].equals("sqrt")) {
                     output = context.i18n("mathOperationResult") + " " + Double.toString(sqrt(num1.doubleValue()));
                 } else {
                     HelpCommand.sendFormattedCommandHelp(context);
                     return;
                 }
 
-            } else if(args.length == 4) {
+            } else if (context.args.length == 3) {
 
-                BigDecimal num1 = new BigDecimal(args[2]);
-                BigDecimal num2 = new BigDecimal(args[3]);
+                BigDecimal num1 = new BigDecimal(context.args[1]);
+                BigDecimal num2 = new BigDecimal(context.args[2]);
                 String resultStr = context.i18n("mathOperationResult") + " ";
 
-                switch(args[1]) {
+                switch (context.args[0]) {
                     case "sum":
                     case "add":
                         output = resultStr + num1.add(num2, MathContext.DECIMAL64).toPlainString();

--- a/FredBoat/src/main/java/fredboat/command/util/SayCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/util/SayCommand.java
@@ -41,13 +41,12 @@ public class SayCommand extends Command implements IUtilCommand {
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        if (context.args.length < 2) {
+        if (context.args.length < 1) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }
-        String res = context.msg.getRawContent().substring(context.args[0].length() + 1);
-        context.reply(TextUtils.ZERO_WIDTH_CHAR + res,
-                message1 -> EventListenerBoat.messagesToDeleteIfIdDeleted.put(context.msg.getIdLong(), message1.getIdLong())
+        context.reply(TextUtils.ZERO_WIDTH_CHAR + context.rawArgs,
+                message -> EventListenerBoat.messagesToDeleteIfIdDeleted.put(context.msg.getIdLong(), message.getIdLong())
         );
 
     }

--- a/FredBoat/src/main/java/fredboat/command/util/SayCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/util/SayCommand.java
@@ -41,7 +41,7 @@ public class SayCommand extends Command implements IUtilCommand {
 
     @Override
     public void onInvoke(@Nonnull CommandContext context) {
-        if (context.args.length < 1) {
+        if (!context.hasArguments()) {
             HelpCommand.sendFormattedCommandHelp(context);
             return;
         }

--- a/FredBoat/src/main/java/fredboat/command/util/UserInfoCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/util/UserInfoCommand.java
@@ -50,7 +50,7 @@ public class UserInfoCommand extends Command implements IUtilCommand {
         StringBuilder knownServers = new StringBuilder();
         List<String> matchedGuildNames = new ArrayList<>();
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern("dd-MMM-yyyy");
-        if (context.args.length < 1) {
+        if (!context.hasArguments()) {
             target = context.invoker;
         } else {
             target = ArgumentUtil.checkSingleFuzzyMemberSearchResult(context, context.rawArgs, true);

--- a/FredBoat/src/main/java/fredboat/command/util/UserInfoCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/util/UserInfoCommand.java
@@ -50,10 +50,10 @@ public class UserInfoCommand extends Command implements IUtilCommand {
         StringBuilder knownServers = new StringBuilder();
         List<String> matchedGuildNames = new ArrayList<>();
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern("dd-MMM-yyyy");
-        if (context.args.length == 1) {
+        if (context.args.length < 1) {
             target = context.invoker;
         } else {
-            target = ArgumentUtil.checkSingleFuzzyMemberSearchResult(context, context.args[1], true);
+            target = ArgumentUtil.checkSingleFuzzyMemberSearchResult(context, context.rawArgs, true);
         }
         if (target == null) return;
         FredBoat.getAllGuilds().forEach(guild -> {

--- a/FredBoat/src/main/java/fredboat/command/util/WeatherCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/util/WeatherCommand.java
@@ -24,19 +24,12 @@ public class WeatherCommand extends Command implements IUtilCommand {
     }
 
     @Override
-    public void onInvoke(CommandContext context) {
+    public void onInvoke(@Nonnull CommandContext context) {
 
         context.sendTyping();
-        if (context.args.length > 1) {
+        if (context.args.length > 0) {
             try {
-
-                StringBuilder argStringBuilder = new StringBuilder();
-                for (int i = 1; i < context.args.length; i++) {
-                    argStringBuilder.append(context.args[i]);
-                    argStringBuilder.append(" ");
-                }
-
-                String query = argStringBuilder.toString().trim();
+                String query = context.rawArgs;
                 String alphabeticalQuery = query.replaceAll("[^A-Za-z]", "");
 
                 if (alphabeticalQuery == null || alphabeticalQuery.length() == 0) {

--- a/FredBoat/src/main/java/fredboat/commandmeta/CommandManager.java
+++ b/FredBoat/src/main/java/fredboat/commandmeta/CommandManager.java
@@ -48,7 +48,6 @@ import net.dv8tion.jda.core.entities.TextChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -140,54 +139,6 @@ public class CommandManager {
             TextUtils.handleException(e, context);
         }
 
-    }
-
-    public static String[] commandToArguments(String cmd) {
-        ArrayList<String> a = new ArrayList<>();
-        int argi = 0;
-        boolean isInQuote = false;
-
-        for (Character ch : cmd.toCharArray()) {
-            if (Character.isWhitespace(ch) && !isInQuote) {
-                String arg = null;
-                try {
-                    arg = a.get(argi);
-                } catch (IndexOutOfBoundsException e) {
-                }
-                if (arg != null) {
-                    argi++;//On to the next arg
-                }//else ignore
-
-            } else if (ch.equals('"')) {
-                isInQuote = !isInQuote;
-            } else {
-                a = writeToArg(a, argi, ch);
-            }
-        }
-
-        String[] newA = new String[a.size()];
-        int i = 0;
-        for (String str : a) {
-            newA[i] = str;
-            i++;
-        }
-
-        return newA;
-    }
-
-    private static ArrayList<String> writeToArg(ArrayList<String> a, int argi, char ch) {
-        String arg = null;
-        try {
-            arg = a.get(argi);
-        } catch (IndexOutOfBoundsException ignored) {
-        }
-        if (arg == null) {
-            a.add(argi, String.valueOf(ch));
-        } else {
-            a.set(argi, arg + ch);
-        }
-
-        return a;
     }
 
     //holder class pattern for the checker

--- a/FredBoat/src/main/java/fredboat/commandmeta/abs/CommandContext.java
+++ b/FredBoat/src/main/java/fredboat/commandmeta/abs/CommandContext.java
@@ -26,10 +26,10 @@
 package fredboat.commandmeta.abs;
 
 import fredboat.Config;
-import fredboat.commandmeta.CommandManager;
 import fredboat.commandmeta.CommandRegistry;
 import fredboat.messaging.CentralMessaging;
 import fredboat.messaging.internal.Context;
+import fredboat.util.DiscordUtil;
 import net.dv8tion.jda.core.Permission;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.Member;
@@ -40,6 +40,10 @@ import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -53,45 +57,80 @@ import java.util.regex.Pattern;
 public class CommandContext extends Context {
 
     private static final Logger log = LoggerFactory.getLogger(CommandContext.class);
-    private static final Pattern COMMAND_NAME_PREFIX = Pattern.compile("(\\w+)");
 
-    public final Guild guild;
-    public final TextChannel channel;
-    public final Member invoker;
-    public final Message msg;
+    // https://regex101.com/r/ceFMeF/6
+    //group 1 is the mention, group 2 is the id of the mention, group 3 is the rest of the input including new lines
+    public static final Pattern MENTION_PREFIX = Pattern.compile("^(<@!?([0-9]+)>)(.*)$", Pattern.DOTALL);
 
-    public String prefix = Config.CONFIG.getPrefix();  // useless for now but custom prefixes anyone?
-    public String trigger = "";                        // the command trigger, e.g. "play", or "p", or "pLaY", whatever the user typed
-    public String cmdName = "";                        // this is the actual command name
-    public String[] args = new String[0];              // the arguments including prefix + trigger in args[0]
-    public Command command = null;
+    //@formatter:off
+    @Nonnull public final Guild guild;
+    @Nonnull public final TextChannel channel;
+    @Nonnull public final Member invoker;
+    @Nonnull public final Message msg;
+
+    @Nonnull public String prefix = Config.CONFIG.getPrefix();  // the prefix that this context was called with. could be a mention, default prefix or a custom one
+    @Nonnull public String trigger = "";                        // the command trigger, e.g. "play", or "p", or "pLaY", whatever the user typed
+    @Nonnull public String cmdName = "";                        // this is the fredboat internal command name, e.g. "play"
+    @Nonnull public String[] args = new String[0];              // the arguments split by whitespace, excluding prefix and trigger
+    @Nonnull public String rawArgs = "";                        // raw arguments excluding prefix and trigger, trimmed
+    @SuppressWarnings("ConstantConditions")//the parsing code handles setting this to a nonnull value
+    @Nonnull public Command command = null;
+    //@formatter:on
 
     /**
      * @param event the event to be parsed
      * @return The full context for the triggered command, or null if it's not a command that we know.
      */
     public static CommandContext parse(MessageReceivedEvent event) {
-        Matcher matcher = COMMAND_NAME_PREFIX.matcher(event.getMessage().getContent());
-        if (matcher.find()) {
+        String selfId = DiscordUtil.getApplicationInfo(event.getJDA()).botId;
+        String raw = event.getMessage().getRawContent();
+
+        String triggeredPrefix;
+        String input;
+        Matcher mentionMatcher = MENTION_PREFIX.matcher(raw);
+        // either starts with a mention of us
+        if (mentionMatcher.find() && mentionMatcher.group(2).equals(selfId)) {
+            triggeredPrefix = mentionMatcher.group(1);
+            input = mentionMatcher.group(3).trim();
+        }
+        // or starts with our prefix
+        else if (raw.startsWith(Config.CONFIG.getPrefix())) {
+            triggeredPrefix = Config.CONFIG.getPrefix();
+            input = raw.substring(triggeredPrefix.length());
+        } else {
+            //no match
+            return null;
+        }
+        input = input.trim();// eliminate possible whitespace between the mention/prefix and the rest of the input
+        if (input.isEmpty()) {
+            return null; //no command will be detectable from an empty input
+        }
+
+        String[] args = input.split("\\s+"); //split by any length of white space characters (including new lines)
+        if (args.length < 1) {
+            return null; //while this shouldn't technically be possible due to the preprocessing of the input, better be safe than throw exceptions
+        }
+
+        String commandTrigger = args[0];
+
+        CommandRegistry.CommandEntry entry = CommandRegistry.getCommand(commandTrigger.toLowerCase());
+        if (entry == null) {
+            log.info("Unknown command:\t{}", commandTrigger);
+            return null;
+        } else {
             CommandContext context = new CommandContext(
                     event.getGuild(),
                     event.getTextChannel(),
                     event.getMember(),
                     event.getMessage());
 
-            context.trigger = matcher.group();
-            CommandRegistry.CommandEntry entry = CommandRegistry.getCommand(context.trigger.toLowerCase());
-            if (entry != null) {
-                context.cmdName = entry.name;
-                context.command = entry.command;
-                context.args = CommandManager.commandToArguments(context.msg.getRawContent());
-                return context;
-            } else {
-                log.info("Unknown command:\t{}", context.trigger);
-                return null;
-            }
-        } else {
-            return null;
+            context.prefix = triggeredPrefix;
+            context.trigger = commandTrigger;
+            context.cmdName = entry.name;
+            context.command = entry.command;
+            context.args = Arrays.copyOfRange(args, 1, args.length);//exclude args[0] that contains the command trigger
+            context.rawArgs = input.replaceFirst(commandTrigger, "").trim();
+            return context;
         }
     }
 
@@ -109,6 +148,28 @@ public class CommandContext extends Context {
         TextChannel tc = msg.getTextChannel();
         if (tc != null && hasPermissions(tc, Permission.MESSAGE_MANAGE)) {
             CentralMessaging.deleteMessage(msg);
+        }
+    }
+
+    /**
+     * @return an adjusted list of mentions in case the prefix mention is used to exclude it. This method should always
+     * be used over Message#getMentions()
+     */
+    public List<User> getMentionedUsers() {
+        Matcher mentionInPrefix = MENTION_PREFIX.matcher(prefix);
+        if (!mentionInPrefix.matches()) {
+            // no match in the prefix, we good
+            return msg.getMentionedUsers();
+        } else {
+            //remove the first mention
+            List<User> mentions = new ArrayList<>(msg.getMentionedUsers());
+            if (!mentions.isEmpty()) {
+                mentions.remove(0);
+                //FIXME: this will mess with the mentions if the bot was mentioned at a later place in the messagea second time,
+                // for example @bot hug @bot will not trigger a self hug message
+                // low priority, this is mostly a cosmetic issue
+            }
+            return mentions;
         }
     }
 

--- a/FredBoat/src/main/java/fredboat/commandmeta/abs/CommandContext.java
+++ b/FredBoat/src/main/java/fredboat/commandmeta/abs/CommandContext.java
@@ -173,21 +173,29 @@ public class CommandContext extends Context {
         }
     }
 
+    public boolean hasArguments() {
+        return args.length > 0 && !rawArgs.isEmpty();
+    }
+
+    @Nonnull
     @Override
     public TextChannel getTextChannel() {
         return channel;
     }
 
+    @Nonnull
     @Override
     public Guild getGuild() {
         return guild;
     }
 
+    @Nonnull
     @Override
     public Member getMember() {
         return invoker;
     }
 
+    @Nonnull
     @Override
     public User getUser() {
         return invoker.getUser();

--- a/FredBoat/src/main/java/fredboat/util/ArgumentUtil.java
+++ b/FredBoat/src/main/java/fredboat/util/ArgumentUtil.java
@@ -29,7 +29,6 @@ import fredboat.commandmeta.abs.CommandContext;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.IMentionable;
 import net.dv8tion.jda.core.entities.Member;
-import net.dv8tion.jda.core.entities.Message;
 import net.dv8tion.jda.core.entities.Role;
 
 import javax.annotation.Nonnull;
@@ -148,12 +147,6 @@ public class ArgumentUtil {
                         + TextUtils.asCodeBlock(searchResults.toString()));
                 return null;
         }
-    }
-
-    public static String getSearchTerm(Message message, String[] args, int argsToStrip) {
-        String raw = message.getRawContent();
-        raw = raw.substring(args[0].length() + args[1].length() + 2); //arg0 is prefix, arg1 is add / remove and + 2 for the 2 spaces
-        return raw.substring(raw.indexOf(args[argsToStrip]));
     }
 
     /**

--- a/FredBoat/src/main/java/fredboat/util/DiscordUtil.java
+++ b/FredBoat/src/main/java/fredboat/util/DiscordUtil.java
@@ -61,7 +61,11 @@ public class DiscordUtil {
     }
 
     public static long getOwnerId(@Nonnull JDA jda) {
-        return getApplicationInfo(jda).ownerId;
+        return getApplicationInfo(jda).ownerIdLong;
+    }
+
+    public static long getSelfId(@Nonnull JDA jda) {
+        return getApplicationInfo(jda).botIdLong;
     }
 
     public static boolean isMainBotPresent(Guild guild) {
@@ -159,8 +163,8 @@ public class DiscordUtil {
     // ########## Moderation related helper functions
     public static String getReasonForModAction(CommandContext context) {
         String r = null;
-        if (context.args.length > 2) {
-            r = String.join(" ", Arrays.copyOfRange(context.args, 2, context.args.length));
+        if (context.args.length > 1) { //ignore the first arg which contains the name/mention of the user
+            r = String.join(" ", Arrays.copyOfRange(context.args, 1, context.args.length));
         }
 
         return context.i18n("modReason") + ": " + (r != null ? r : "No reason provided.");
@@ -180,21 +184,25 @@ public class DiscordUtil {
     public static class DiscordAppInfo {
         public final boolean doesBotRequireCodeGrant;
         public final boolean isBotPublic;
-        public final long botId;
+        public final long botIdLong;
+        public final String botId;
         public final String iconId;
         public final String description;
         public final String appName;
-        public final long ownerId;
+        public final long ownerIdLong;
+        public final String ownerId;
         public final String ownerName;
 
         public DiscordAppInfo(ApplicationInfo applicationInfo) {
             this.doesBotRequireCodeGrant = applicationInfo.doesBotRequireCodeGrant();
             this.isBotPublic = applicationInfo.isBotPublic();
-            this.botId = applicationInfo.getIdLong();
+            this.botIdLong = applicationInfo.getIdLong();
+            this.botId = applicationInfo.getId();
             this.iconId = applicationInfo.getIconId();
             this.description = applicationInfo.getDescription();
             this.appName = applicationInfo.getName();
-            this.ownerId = applicationInfo.getOwner().getIdLong();
+            this.ownerIdLong = applicationInfo.getOwner().getIdLong();
+            this.ownerId = applicationInfo.getOwner().getId();
             this.ownerName = applicationInfo.getOwner().getName();
         }
     }

--- a/FredBoat/src/test/java/fredboat/command/admin/TestCommandTest.java
+++ b/FredBoat/src/test/java/fredboat/command/admin/TestCommandTest.java
@@ -28,7 +28,7 @@ class TestCommandTest extends ProvideJDASingleton {
     void onInvoke() {
         Assumptions.assumeFalse(isTravisEnvironment(), () -> "Aborting test: Travis CI detected");
         Assumptions.assumeTrue(initialized);
-        String[] args = {"test", "10", "10"};
+        String[] args = {"10", "10"};
 
         //test the connection if one was specified
         String jdbcUrl = Config.CONFIG.getJdbcUrl();
@@ -44,7 +44,7 @@ class TestCommandTest extends ProvideJDASingleton {
         }
 
         //test the internal SQLite db
-        args[1] = args[2] = "2";
+        args[0] = args[1] = "2";
         DatabaseManager dbm = new DatabaseManager("jdbc:sqlite:fredboat.db", "org.hibernate.dialect.SQLiteDialect", 1);
         try {
             dbm.startup();


### PR DESCRIPTION
First step to custom prefixes is to make FredBoat reliably answer when mentioned - that's what this PR does.
Cleaned up the parsing of arguments - they are really just the arguments now, split by whitespace, no prefix or commands to be handled in args[0] etc. That's why a lot of commands have been touched in this PR, but that's mostly just refactoring.
Important changes are found in EventListenerBoat and CommandContext.