### PR TITLE
Feature/ff additions

### DIFF
--- a/FredBoat/config.yaml
+++ b/FredBoat/config.yaml
@@ -6,6 +6,7 @@ restServerEnabled: true        # Set this to false if you are running multiple F
 admins:            []          # Add comma separated userIds and roleIds that should have access to bot admin commands
 useAutoBlacklist:  true        # Set to true to automatically blacklist users who frequently hit the rate limits
 game:              ""          # Set the displayed game/status. Leave empty quote marks for the default status
+continuePlayback:  false        # Set to true to force the player to continue playback even if left alone
 
 enableYouTube:     true        # Set to true to enable playing YouTube links
 enableSoundCloud:  true        # Set to true to enable playing SoundCloud links
@@ -16,3 +17,5 @@ enableMixer:       true        # Set to true to enable playing Mixer links
 enableSpotify:     true        # Set to true to enable playing Spotify links
 enableHttp:        true        # Set to true to enable playing direct links
 
+# THIS IS TEMPORARY UNTIL COMMANDS ARE MODULARIZED
+tempUseVoiceChannelCleanup: true # This acts as an override if set to false no vcCleanupAgent will be run

--- a/FredBoat/src/main/java/fredboat/Config.java
+++ b/FredBoat/src/main/java/fredboat/Config.java
@@ -94,6 +94,7 @@ public class Config {
     private List<String> adminIds = new ArrayList<>();
     private boolean useAutoBlacklist = false;
     private String game = "";
+    private boolean continuePlayback = false;
     private List<LavalinkHost> lavalinkHosts = new ArrayList<>();
     private String openWeatherKey;
     private String sentryDsn;
@@ -120,6 +121,9 @@ public class Config {
     private Boolean mixerAudio;
     private Boolean spotifyAudio;
     private Boolean httpAudio;
+
+    //Temp configs
+    private boolean useVoiceChannelCleanup = true;
 
     @SuppressWarnings("unchecked")
     public Config(File credentialsFile, File configFile) {
@@ -170,6 +174,7 @@ public class Config {
             }
             useAutoBlacklist = (boolean) config.getOrDefault("useAutoBlacklist", useAutoBlacklist);
             game = (String) config.getOrDefault("game", "");
+            continuePlayback = (boolean) config.getOrDefault("continuePlayback", continuePlayback);
 
             log.info("Using prefix: " + prefix);
 
@@ -273,6 +278,9 @@ public class Config {
             mixerAudio = (Boolean) config.getOrDefault("enableMixer", true);
             spotifyAudio = (Boolean) config.getOrDefault("enableSpotify", true);
             httpAudio = (Boolean) config.getOrDefault("enableHttp", false);
+
+            //temp configs
+            useVoiceChannelCleanup = (boolean) config.getOrDefault("tempUseVoiceChannelCleanup", true);
 
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -435,6 +443,8 @@ public class Config {
         }
     }
 
+    public boolean getContinuePlayback() { return continuePlayback; }
+
     public String getTestBotToken() {
         return testBotToken;
     }
@@ -517,4 +527,6 @@ public class Config {
     public boolean isHttpEnabled() {
         return httpAudio;
     }
+
+    public boolean useVoiceChannelCleanup() {return useVoiceChannelCleanup; }
 }

--- a/FredBoat/src/main/java/fredboat/FredBoat.java
+++ b/FredBoat/src/main/java/fredboat/FredBoat.java
@@ -26,10 +26,7 @@
 package fredboat;
 
 import com.sedmelluq.discord.lavaplayer.tools.PlayerLibrary;
-import fredboat.agent.CarbonitexAgent;
-import fredboat.agent.DBConnectionWatchdogAgent;
-import fredboat.agent.FredBoatAgent;
-import fredboat.agent.StatsAgent;
+import fredboat.agent.*;
 import fredboat.api.API;
 import fredboat.audio.player.LavalinkManager;
 import fredboat.audio.queue.MusicPersistenceHandler;
@@ -150,6 +147,14 @@ public abstract class FredBoat {
             MainCommandInitializer.initCommands();
 
         MusicCommandInitializer.initCommands();
+
+        // The null check is to ensure we can run this in a test run
+        if (FeatureFlags.LEAVE_EMPTY_VC.isActive()) {
+            log.info("Starting VoiceChannelCleanupAgent.");
+            FredBoatAgent.start(new VoiceChannelCleanupAgent());
+        } else {
+            log.info("Skipped setting up the VoiceChannelCleanupAgent since its disabled in FeatureFlags.");
+        }
 
         log.info("Loaded commands, registry size is " + CommandRegistry.getSize());
 

--- a/FredBoat/src/main/java/fredboat/FredBoat.java
+++ b/FredBoat/src/main/java/fredboat/FredBoat.java
@@ -148,7 +148,6 @@ public abstract class FredBoat {
 
         MusicCommandInitializer.initCommands();
 
-        // The null check is to ensure we can run this in a test run
         if (FeatureFlags.LEAVE_EMPTY_VC.isActive()) {
             log.info("Starting VoiceChannelCleanupAgent.");
             FredBoatAgent.start(new VoiceChannelCleanupAgent());

--- a/FredBoat/src/main/java/fredboat/FredBoat.java
+++ b/FredBoat/src/main/java/fredboat/FredBoat.java
@@ -148,11 +148,12 @@ public abstract class FredBoat {
 
         MusicCommandInitializer.initCommands();
 
-        if (FeatureFlags.LEAVE_EMPTY_VC.isActive()) {
+        if (!Config.CONFIG.isPatronDistribution() && Config.CONFIG.useVoiceChannelCleanup()) {
             log.info("Starting VoiceChannelCleanupAgent.");
             FredBoatAgent.start(new VoiceChannelCleanupAgent());
         } else {
-            log.info("Skipped setting up the VoiceChannelCleanupAgent since its disabled in FeatureFlags.");
+            log.info("Skipped setting up the VoiceChannelCleanupAgent, " +
+                    "either running Patron distro or overridden by temp config");
         }
 
         log.info("Loaded commands, registry size is " + CommandRegistry.getSize());

--- a/FredBoat/src/main/java/fredboat/commandmeta/init/MusicCommandInitializer.java
+++ b/FredBoat/src/main/java/fredboat/commandmeta/init/MusicCommandInitializer.java
@@ -24,9 +24,6 @@
 
 package fredboat.commandmeta.init;
 
-import fredboat.Config;
-import fredboat.agent.FredBoatAgent;
-import fredboat.agent.VoiceChannelCleanupAgent;
 import fredboat.command.admin.*;
 import fredboat.command.maintenance.*;
 import fredboat.command.moderation.*;
@@ -46,7 +43,6 @@ import fredboat.command.util.MusicHelpCommand;
 import fredboat.command.util.UserInfoCommand;
 import fredboat.commandmeta.CommandRegistry;
 import fredboat.perms.PermissionLevel;
-import fredboat.shared.constant.DistributionEnum;
 import fredboat.util.rest.SearchUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -133,13 +129,6 @@ public class MusicCommandInitializer {
         CommandRegistry.registerCommand(new PermissionsCommand(PermissionLevel.ADMIN, "admin"));
         CommandRegistry.registerCommand(new PermissionsCommand(PermissionLevel.DJ, "dj"));
         CommandRegistry.registerCommand(new PermissionsCommand(PermissionLevel.USER, "user"));
-
-        // The null check is to ensure we can run this in a test run
-        if (Config.CONFIG == null || Config.CONFIG.getDistribution() != DistributionEnum.PATRON) {
-            FredBoatAgent.start(new VoiceChannelCleanupAgent());
-        } else {
-            log.info("Skipped setting up the VoiceChannelCleanupAgent since we are running as PATRON distribution.");
-        }
     }
 
     /**

--- a/FredBoat/src/main/java/fredboat/event/EventListenerBoat.java
+++ b/FredBoat/src/main/java/fredboat/event/EventListenerBoat.java
@@ -254,6 +254,9 @@ public class EventListenerBoat extends AbstractEventListener {
     }
 
     private void checkForAutoPause(VoiceChannel channelLeft) {
+        if (!FeatureFlags.PAUSE_IF_ALONE.isActive())
+            return;
+
         Guild guild = channelLeft.getGuild();
         GuildPlayer player = PlayerRegistry.getExisting(guild);
 

--- a/FredBoat/src/main/java/fredboat/event/EventListenerBoat.java
+++ b/FredBoat/src/main/java/fredboat/event/EventListenerBoat.java
@@ -254,7 +254,7 @@ public class EventListenerBoat extends AbstractEventListener {
     }
 
     private void checkForAutoPause(VoiceChannel channelLeft) {
-        if (!FeatureFlags.PAUSE_IF_ALONE.isActive())
+        if (Config.CONFIG.getContinuePlayback())
             return;
 
         Guild guild = channelLeft.getGuild();


### PR DESCRIPTION
This Change will allow Selfhosters to turn off the VoiceChannelCleanupAgent regardless of distribution as well as allow them to change if the player should pause when its left alone in the voice channel.

The use cases
If self-hosters want to run the full bot i.e dev distro but don't want to have the vcCleanup running. And we've gotten multiple requests from users to have a "radio" which plays 24/7, while we cant do that due to resources, self-hosters should be able to turn it on for them if they think they want.

This pr should require no change from us on the public bot as it defaults to the current Fredboat settings.
**But** the patron bot will need to have the vcCleanup disabled