### PR TITLE
Adjust hardcoding for FredBoat Hangout

### DIFF
--- a/FredBoat/src/main/java/fredboat/commandmeta/CommandManager.java
+++ b/FredBoat/src/main/java/fredboat/commandmeta/CommandManager.java
@@ -81,10 +81,9 @@ public class CommandManager {
         if (guild.getIdLong() == BotConstants.FREDBOAT_HANGOUT_ID && guild.getJDA().getSelfUser().getIdLong() == BotConstants.MUSIC_BOT_ID) {
             if (!channel.getId().equals("174821093633294338") // #spam_and_music
                     && !channel.getId().equals("217526705298866177") // #staff
-                    && !invoker.getUser().getId().equals("203330266461110272")//Cynth
-                    && !invoker.getUser().getId().equals("81011298891993088")) { // Fre_d
+                    && !PermsUtil.checkPerms(PermissionLevel.ADMIN, invoker)) {
                 context.deleteMessage();
-                context.replyWithName("Please don't spam music commands outside of <#174821093633294338>.",
+                context.replyWithName("Please read <#219483023257763842> for server rules and only use commands in <#174821093633294338>!",
                         msg -> CentralMessaging.restService.schedule(() -> CentralMessaging.deleteMessage(msg),
                                 5, TimeUnit.SECONDS));
                 return;

--- a/FredBoat/src/main/java/fredboat/commandmeta/CommandManager.java
+++ b/FredBoat/src/main/java/fredboat/commandmeta/CommandManager.java
@@ -35,6 +35,7 @@ import fredboat.messaging.CentralMessaging;
 import fredboat.perms.PermissionLevel;
 import fredboat.perms.PermsUtil;
 import fredboat.shared.constant.BotConstants;
+import fredboat.util.DiscordUtil;
 import fredboat.util.TextUtils;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.Member;
@@ -77,8 +78,8 @@ public class CommandManager {
             }
         }
 
-        //Hardcode music commands in FredBoatHangout. Blacklist any channel that isn't #spam_and_music or #staff, but whitelist Frederikam
-        if (guild.getIdLong() == BotConstants.FREDBOAT_HANGOUT_ID && guild.getJDA().getSelfUser().getIdLong() == BotConstants.MUSIC_BOT_ID) {
+        //Hardcode music commands in FredBoatHangout. Blacklist any channel that isn't #spam_and_music or #staff, but whitelist Admins
+        if (guild.getIdLong() == BotConstants.FREDBOAT_HANGOUT_ID && DiscordUtil.isOfficialBot()) {
             if (!channel.getId().equals("174821093633294338") // #spam_and_music
                     && !channel.getId().equals("217526705298866177") // #staff
                     && !PermsUtil.checkPerms(PermissionLevel.ADMIN, invoker)) {

--- a/FredBoat/src/main/java/fredboat/commandmeta/CommandManager.java
+++ b/FredBoat/src/main/java/fredboat/commandmeta/CommandManager.java
@@ -27,11 +27,7 @@ package fredboat.commandmeta;
 
 
 import fredboat.audio.player.PlayerRegistry;
-import fredboat.command.fun.AkinatorCommand;
-import fredboat.commandmeta.abs.Command;
-import fredboat.commandmeta.abs.CommandContext;
-import fredboat.commandmeta.abs.ICommandRestricted;
-import fredboat.commandmeta.abs.IMusicCommand;
+import fredboat.commandmeta.abs.*;
 import fredboat.feature.PatronageChecker;
 import fredboat.feature.metrics.Metrics;
 import fredboat.feature.togglz.FeatureFlags;
@@ -81,10 +77,8 @@ public class CommandManager {
             }
         }
 
-        //Hardcode music commands in FredBoatHangout. Blacklist any channel that isn't #general or #staff, but whitelist Frederikam
-        if ((invoked instanceof IMusicCommand || invoked instanceof AkinatorCommand) // the hate is real
-                && guild.getIdLong() == BotConstants.FREDBOAT_HANGOUT_ID
-                && guild.getJDA().getSelfUser().getIdLong() == BotConstants.MUSIC_BOT_ID) {
+        //Hardcode music commands in FredBoatHangout. Blacklist any channel that isn't #spam_and_music or #staff, but whitelist Frederikam
+        if (guild.getIdLong() == BotConstants.FREDBOAT_HANGOUT_ID && guild.getJDA().getSelfUser().getIdLong() == BotConstants.MUSIC_BOT_ID) {
             if (!channel.getId().equals("174821093633294338") // #spam_and_music
                     && !channel.getId().equals("217526705298866177") // #staff
                     && !invoker.getUser().getId().equals("203330266461110272")//Cynth


### PR DESCRIPTION
Adjust CommandManager.java so that the hardcoding for FredBoat Hangout now blocks all types of command (where it was previously just music commands) in channels that aren't #spam_and_music or #staff unless the user is Fre_d or Cynth