### PR TITLE
Fix hardcoded 0th index in time for tracks

### DIFF
--- a/FredBoat/src/main/java/fredboat/command/music/control/SelectCommand.java
+++ b/FredBoat/src/main/java/fredboat/command/music/control/SelectCommand.java
@@ -111,7 +111,7 @@ public class SelectCommand extends Command implements IMusicCommand, ICommandRes
 
                     String msg = context.i18nFormat("selectSuccess", validChoices.get(i),
                             TextUtils.escapeAndDefuse(selectedTracks[i].getInfo().title),
-                            TextUtils.formatTime(selectedTracks[0].getInfo().length));
+                            TextUtils.formatTime(selectedTracks[i].getInfo().length));
                     if (i < validChoices.size()) {
                         outputMsgBuilder.append("\n");
                     }


### PR DESCRIPTION
Fixes issue in which all tracks would show as though they had the same length as the first one in the list