### PR TITLE
Update docker-compose to match updated guide

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,8 @@ services:
     # FredBoat selfhosting website and/or the selfhosters channel (see top of this file for how to get to these places)
     # Once you use the dev branch, you may not be able to go back to stable without deleting your database.
     # To run on (some) arm based machines, prepend the tag with arm64v8-, for example: fredboat/quarterdeck:arm64v8-dev-v1
-    image: fredboat/quarterdeck:stable-v1
-    #image: fredboat/quarterdeck:dev-v1
+    #image: fredboat/quarterdeck:stable-v1
+    image: fredboat/quarterdeck:dev-v1
     restart: always
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
@@ -65,8 +65,8 @@ services:
     # for choosing between stable or dev, read the paragraph above in the Quarterdeck section
     # IMPORTANT: both quarterdeck and fredboat need to either be on the stable, or on the dev branch
     # To run on (some) arm based machines, prepend the tag with arm64v8-, for example: fredboat/fredboat:arm64v8-dev-v3
-    image: fredboat/fredboat:stable-v3
-    #image: fredboat/fredboat:dev-v3
+    #image: fredboat/fredboat:stable-v3
+    image: fredboat/fredboat:dev-v3
     #build: ./FredBoat #useful alternative for developers
 
     restart: on-failure:3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,8 +65,8 @@ services:
     # for choosing between stable or dev, read the paragraph above in the Quarterdeck section
     # IMPORTANT: both quarterdeck and fredboat need to either be on the stable, or on the dev branch
     # To run on (some) arm based machines, prepend the tag with arm64v8-, for example: fredboat/fredboat:arm64v8-dev-v3
-    #image: fredboat/fredboat:stable-v3
-    image: fredboat/fredboat:dev-v3
+    image: fredboat/fredboat:stable-v3
+    #image: fredboat/fredboat:dev-v3
     #build: ./FredBoat #useful alternative for developers
 
     restart: on-failure:3


### PR DESCRIPTION
As https://github.com/FredBoat/fredboat.com/pull/28 is now live and people are using it, these should be changed over - especially Quarterdeck - since there's no `stable-v1` build (and never was 😆)

Since everyone following the updated guide will be aware of the selfhosting changes, and all pulling dev, I think the second change (to `dev-v3`) is fine as well. I've been running it for months.