### PR TITLE
Add spring application context to eval command

### DIFF
--- a/FredBoat/src/main/java/fredboat/command/admin/EvalCommand.kt
+++ b/FredBoat/src/main/java/fredboat/command/admin/EvalCommand.kt
@@ -34,6 +34,7 @@ import fredboat.messaging.internal.Context
 import fredboat.util.TextUtils
 import lavalink.client.player.LavalinkPlayer
 import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationContext
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
@@ -42,7 +43,11 @@ import javax.script.ScriptEngine
 import javax.script.ScriptEngineManager
 import javax.script.ScriptException
 
-class EvalCommand(name: String, vararg aliases: String) : Command(name, *aliases), ICommandRestricted {
+class EvalCommand(
+        private val springContext: () -> ApplicationContext,
+        name: String,
+        vararg aliases: String
+) : Command(name, *aliases), ICommandRestricted {
 
     companion object {
         private val log = LoggerFactory.getLogger(EvalCommand::class.java)
@@ -115,6 +120,7 @@ class EvalCommand(name: String, vararg aliases: String) : Command(name, *aliases
             engine.put("player", player)
             engine.put("pm", Launcher.botController.audioPlayerManager)
             engine.put("context", context)
+            engine.put("spring", springContext.invoke())
         }
 
         val service = Executors.newScheduledThreadPool(1) { r -> Thread(r, "Eval comm execution") }

--- a/FredBoat/src/main/java/fredboat/commandmeta/CommandInitializer.java
+++ b/FredBoat/src/main/java/fredboat/commandmeta/CommandInitializer.java
@@ -50,10 +50,12 @@ import fredboat.util.rest.TrackSearcher;
 import fredboat.util.rest.Weather;
 import fredboat.util.rest.YoutubeAPI;
 import io.prometheus.client.guava.cache.CacheMetricsCollector;
+import org.springframework.context.ApplicationContext;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.function.Supplier;
 
 public class CommandInitializer {
 
@@ -73,7 +75,7 @@ public class CommandInitializer {
     public static void initCommands(@Nullable CacheMetricsCollector cacheMetrics, Weather weather, TrackSearcher trackSearcher,
                                     VideoSelectionCache videoSelectionCache, SentryConfiguration sentryConfiguration,
                                     PlayerLimiter playerLimiter, YoutubeAPI youtubeAPI, Sentinel sentinel,
-                                    SentinelCountingService countingService) {
+                                    SentinelCountingService countingService, Supplier<ApplicationContext> springContext) {
 
         // Administrative Module - always on (as in, essential commands for BOT_ADMINs and BOT_OWNER)
         CommandRegistry adminModule = new CommandRegistry(Module.ADMIN);
@@ -82,7 +84,7 @@ public class CommandInitializer {
         adminModule.registerCommand(new DisableCommandsCommand("disable"));
         adminModule.registerCommand(new DiscordPermissionCommand("discordpermissions", "disperms"));
         adminModule.registerCommand(new EnableCommandsCommand("enable"));
-        adminModule.registerCommand(new EvalCommand("eval"));
+        adminModule.registerCommand(new EvalCommand(springContext::get, "eval"));
         adminModule.registerCommand(new ExitCommand("exit"));
         adminModule.registerCommand(new GetNodeCommand("getnode"));
         adminModule.registerCommand(new LeaveServerCommand("leaveserver"));


### PR DESCRIPTION
Allows for usage in the eval command like:

```
;;eval return spring.getBean("shardManager").getGuildById("foo").getName()
```


Transforming the `Supplier<ApplicationContext>` through a kotlin -> java -> kotlin was a bit awkward, hope the code is correct.