### PR TITLE
Updating Sentinel JDK to 11

### DIFF
--- a/FredBoat/Dockerfile.arm64v8
+++ b/FredBoat/Dockerfile.arm64v8
@@ -1,4 +1,4 @@
-FROM arm64v8/openjdk:9-jdk-slim
+FROM arm64v8/openjdk:11-jdk-slim
 
 ENV ENV docker
 

--- a/FredBoat/src/main/java/fredboat/main/Launcher.kt
+++ b/FredBoat/src/main/java/fredboat/main/Launcher.kt
@@ -197,13 +197,13 @@ class Launcher(
             log.info(versionInfo)
 
             val javaVersionMajor = Runtime.version().feature()
-            if (javaVersionMajor != 10) {
+            if (javaVersionMajor != 11) {
                 log.warn("\n\t\t __      ___   ___ _  _ ___ _  _  ___ \n" +
                         "\t\t \\ \\    / /_\\ | _ \\ \\| |_ _| \\| |/ __|\n" +
                         "\t\t  \\ \\/\\/ / _ \\|   / .` || || .` | (_ |\n" +
                         "\t\t   \\_/\\_/_/ \\_\\_|_\\_|\\_|___|_|\\_|\\___|\n" +
                         "\t\t                                      ")
-                log.warn("FredBoat only officially supports Java 10. You are running Java {}", Runtime.version())
+                log.warn("FredBoat only officially supports Java 11. You are running Java {}", Runtime.version())
             }
 
             System.setProperty("spring.config.name", "fredboat")


### PR DESCRIPTION
I've noticed you're preparing for the Sentinel upgrade (PR #531), there are some minor JDK related settings that should be updated. I understand PRs should be made against the dev branch but I figured it would be easier to keep track of changes since your PR is merging sentinel to dev.