### PR TITLE
[FB-551] Fix BOT_OWNER permission for Bots which belong to a Team

### DIFF
--- a/FredBoat/src/main/java/fredboat/config/property/AppConfig.java
+++ b/FredBoat/src/main/java/fredboat/config/property/AppConfig.java
@@ -63,6 +63,8 @@ public interface AppConfig {
 
     List<Long> getAdminIds();
 
+    List<Long> getOwnerIds();
+
     boolean useAutoBlacklist();
 
     int getPlayerLimit();

--- a/FredBoat/src/main/java/fredboat/config/property/AppConfigProperties.java
+++ b/FredBoat/src/main/java/fredboat/config/property/AppConfigProperties.java
@@ -48,6 +48,7 @@ public class AppConfigProperties implements AppConfig {
     private String prefix = "<<";
     private boolean restServerEnabled = false;
     private List<Long> botAdmins = new ArrayList<>();
+    private List<Long> botOwners = new ArrayList<>();
     private boolean autoBlacklist = true;
     private String game = "";
     private boolean continuePlayback = false;
@@ -79,6 +80,11 @@ public class AppConfigProperties implements AppConfig {
     @Override
     public List<Long> getAdminIds() {
         return botAdmins;
+    }
+
+    @Override
+    public List<Long> getOwnerIds() {
+        return botOwners;
     }
 
     @Override
@@ -125,6 +131,10 @@ public class AppConfigProperties implements AppConfig {
 
     public void setBotAdmins(List<Long> botAdmins) {
         this.botAdmins = botAdmins;
+    }
+
+    public void setBotOwners(List<Long> botOwners) {
+        this.botOwners = botOwners;
     }
 
     public void setAutoBlacklist(boolean autoBlacklist) {

--- a/FredBoat/src/main/java/fredboat/perms/PermsUtil.kt
+++ b/FredBoat/src/main/java/fredboat/perms/PermsUtil.kt
@@ -38,8 +38,6 @@ import javax.annotation.CheckReturnValue
 object PermsUtil {
 
     suspend fun getPerms(member: Member): PermissionLevel = when {
-        member.sentinel.applicationInfo.ownerId == member.id
-        -> PermissionLevel.BOT_OWNER // https://fred.moe/Q-EB.png
         isBotOwner(member)
         -> PermissionLevel.BOT_OWNER
         isBotAdmin(member)
@@ -91,12 +89,8 @@ object PermsUtil {
         }
     }
 
-    private fun isBotOwner(member: Member): Boolean {
-        for (id in Launcher.botController.appConfig.ownerIds) {
-            if (member.id == id) return true
-        }
-        return false
-    }
+    private fun isBotOwner(member: Member): Boolean = Launcher.botController.appConfig.ownerIds.contains(member.id) or
+            (member.sentinel.applicationInfo.ownerId == member.id)
 
     /**
      * returns true if the member is or holds a role defined as admin in the configuration file

--- a/FredBoat/src/main/java/fredboat/perms/PermsUtil.kt
+++ b/FredBoat/src/main/java/fredboat/perms/PermsUtil.kt
@@ -40,6 +40,10 @@ object PermsUtil {
     suspend fun getPerms(member: Member): PermissionLevel = when {
         member.sentinel.applicationInfo.ownerId == member.id
         -> PermissionLevel.BOT_OWNER // https://fred.moe/Q-EB.png
+
+        //TODO: This is a kinda "fix" for Bots that belong to a Team since we currently can't query the members in a team as a bot (https://github.com/discordapp/discord-api-docs/issues/787)
+        isBotOwner(member) -> PermissionLevel.BOT_OWNER
+
         isBotAdmin(member)
         -> PermissionLevel.BOT_ADMIN
         member.hasPermission(Permission.ADMINISTRATOR).awaitSingle()
@@ -87,6 +91,13 @@ object PermsUtil {
             }
             return false
         }
+    }
+
+    private fun isBotOwner(member: Member): Boolean {
+        for (id in Launcher.botController.appConfig.ownerIds) {
+            if (member.id == id) return true
+        }
+        return false
     }
 
     /**

--- a/FredBoat/src/main/java/fredboat/perms/PermsUtil.kt
+++ b/FredBoat/src/main/java/fredboat/perms/PermsUtil.kt
@@ -40,10 +40,8 @@ object PermsUtil {
     suspend fun getPerms(member: Member): PermissionLevel = when {
         member.sentinel.applicationInfo.ownerId == member.id
         -> PermissionLevel.BOT_OWNER // https://fred.moe/Q-EB.png
-
-        //TODO: This is a kinda "fix" for Bots that belong to a Team since we currently can't query the members in a team as a bot (https://github.com/discordapp/discord-api-docs/issues/787)
-        isBotOwner(member) -> PermissionLevel.BOT_OWNER
-
+        isBotOwner(member)
+        -> PermissionLevel.BOT_OWNER
         isBotAdmin(member)
         -> PermissionLevel.BOT_ADMIN
         member.hasPermission(Permission.ADMINISTRATOR).awaitSingle()

--- a/FredBoat/src/main/java/fredboat/perms/PermsUtil.kt
+++ b/FredBoat/src/main/java/fredboat/perms/PermsUtil.kt
@@ -89,8 +89,8 @@ object PermsUtil {
         }
     }
 
-    private fun isBotOwner(member: Member): Boolean = Launcher.botController.appConfig.ownerIds.contains(member.id) or
-            (member.sentinel.applicationInfo.ownerId == member.id)
+    private fun isBotOwner(member: Member): Boolean = Launcher.botController.appConfig.ownerIds.contains(member.id) ||
+            member.sentinel.applicationInfo.ownerId == member.id
 
     /**
      * returns true if the member is or holds a role defined as admin in the configuration file

--- a/FredBoat/src/main/java/fredboat/perms/PermsUtil.kt
+++ b/FredBoat/src/main/java/fredboat/perms/PermsUtil.kt
@@ -90,7 +90,7 @@ object PermsUtil {
     }
 
     private fun isBotOwner(member: Member): Boolean = Launcher.botController.appConfig.ownerIds.contains(member.id) ||
-            member.sentinel.applicationInfo.ownerId == member.id
+            member.sentinel.applicationInfo.ownerId == member.id // https://fred.moe/Q-EB.png
 
     /**
      * returns true if the member is or holds a role defined as admin in the configuration file

--- a/FredBoat/src/test/java/fredboat/testutil/config/MockConfig.kt
+++ b/FredBoat/src/test/java/fredboat/testutil/config/MockConfig.kt
@@ -46,6 +46,8 @@ class MockConfig : AppConfig, AudioSourcesConfig, Credentials, EventLoggerConfig
 
     override fun getAdminIds() = listOf(Raws.botAdminRole.id)
 
+    override fun getOwnerIds() = listOf(Raws.owner.id)
+
     override fun useAutoBlacklist() = false
 
     override fun getGame() = "Passing all tests"

--- a/config/templates/fredboat.yml
+++ b/config/templates/fredboat.yml
@@ -54,6 +54,7 @@ config:
                                   # things happening to your bot in the selfhosting chat you will be publicly taunted.
   prefix:            '<<'         # Default prefix used by the bot
   botAdmins:         []           # Add comma separated userIds and roleIds that should have access to bot admin commands. Find role ids with the ;;roleinfo command
+  botOwners:         []           # Add comma separated userIds that should have access to bot OWNER commands. Mainly intended for Bots that belong to teams
   autoBlacklist:     true         # Set to true to automatically blacklist users who frequently hit the rate limits
   game:              ""           # Set the displayed game/status. Leave empty quote marks for the default status
   continuePlayback:  false        # Set to true to force the player to continue playback even if left alone

--- a/config/templates/fredboat.yml
+++ b/config/templates/fredboat.yml
@@ -54,7 +54,7 @@ config:
                                   # things happening to your bot in the selfhosting chat you will be publicly taunted.
   prefix:            '<<'         # Default prefix used by the bot
   botAdmins:         []           # Add comma separated userIds and roleIds that should have access to bot admin commands. Find role ids with the ;;roleinfo command
-  botOwners:         []           # Add comma separated userIds that should have access to bot OWNER commands. Mainly intended for Bots that belong to teams
+  botOwners:         []           # Add comma separated userIds that should have access to bot OWNER commands. Mainly intended for bots that belong to teams
   autoBlacklist:     true         # Set to true to automatically blacklist users who frequently hit the rate limits
   game:              ""           # Set the displayed game/status. Leave empty quote marks for the default status
   continuePlayback:  false        # Set to true to force the player to continue playback even if left alone


### PR DESCRIPTION
Fixes #551 until discordapp/discord-api-docs#787 allows querying for team members