### PR TITLE
Change bot image to use dev-v4

### DIFF
--- a/config/templates/selfhosting.yml
+++ b/config/templates/selfhosting.yml
@@ -129,7 +129,7 @@ services:
     # for choosing between stable or dev, read the paragraph above in the Quarterdeck section
     # IMPORTANT: both quarterdeck and fredboat need to either be on the stable, or on the dev branch
     # To run on (some) arm based machines, prepend the tag with arm64v8-, for example: fredboat/fredboat:arm64v8-dev-v3
-    image: fredboat/fredboat:sentinel-v3
+    image: fredboat/fredboat:dev-v4
     #build: ./FredBoat #useful alternative for developers
 
     restart: on-failure:3


### PR DESCRIPTION
Sentinel-v3 is not stable and has a lot of issues with playing music and working in general.
It is a commit from November 2018 and should not be in the template files.