### PR TITLE
Feature/clear on empty

### DIFF
--- a/FredBoat/src/main/java/fredboat/command/config/ConfigCommand.kt
+++ b/FredBoat/src/main/java/fredboat/command/config/ConfigCommand.kt
@@ -58,6 +58,7 @@ class ConfigCommand(name: String, vararg aliases: String) : Command(name, *alias
                 .append(context.i18nFormat("configNoArgs", context.guild.name)).append("\n")
                 .append("track_announce = ${gc.isTrackAnnounce}\n")
                 .append("auto_resume = ${gc.isAutoResume}\n")
+                .append("clear_on_empty = ${gc.isClearOnEmpty}")
                 .append("```") //opening ``` is part of the configNoArgs language string
 
         context.reply(mb.build())
@@ -93,6 +94,13 @@ class ConfigCommand(name: String, vararg aliases: String) : Command(name, *alias
                 context.replyWithName("`auto_resume` " + context.i18nFormat("configSetTo", `val`))
             } else {
                 context.reply(context.i18nFormat("configMustBeBoolean", invoker.effectiveName.escapeAndDefuse()))
+            }
+        } else if (key == "clear_on_empty") {
+            if (`val`.equals("true", ignoreCase = true) or `val`.equals("false", ignoreCase = true)) {
+                Launcher.botController.guildConfigService.transformGuildConfig(context.guild.id) {
+                    gc -> gc.setClearOnEmpty(java.lang.Boolean.parseBoolean(`val`))
+                }
+                context.replyWithName("`clear_on_empty`" + context.i18nFormat("configSetTo", `val`))
             }
         } else context.reply(context.i18nFormat("configUnknownKey", invoker.effectiveName.escapeAndDefuse()))
     }

--- a/FredBoat/src/main/java/fredboat/db/transfer/GuildConfig.java
+++ b/FredBoat/src/main/java/fredboat/db/transfer/GuildConfig.java
@@ -35,6 +35,7 @@ public class GuildConfig implements TransferObject<String> {
     private String guildId = "";
     private boolean trackAnnounce = false;
     private boolean autoResume = false;
+    private boolean clearOnEmpty = true;
     private String lang = "en_US";
 
     @Override
@@ -62,6 +63,15 @@ public class GuildConfig implements TransferObject<String> {
 
     public GuildConfig setAutoResume(boolean autoplay) {
         this.autoResume = autoplay;
+        return this;
+    }
+
+    public boolean isClearOnEmpty() {
+        return clearOnEmpty;
+    }
+
+    public GuildConfig setClearOnEmpty(boolean clearOnEmpty) {
+        this.clearOnEmpty = clearOnEmpty;
         return this;
     }
 

--- a/FredBoat/src/main/resources/lang/en_US.properties
+++ b/FredBoat/src/main/resources/lang/en_US.properties
@@ -211,6 +211,7 @@ userinfoBlacklisted=Blacklisted\:
 skipDeniedTooManyTracks=You can't skip someone else's tracks if you are not a DJ.\nConsider using the Voteskip command.
 eventUsersLeftVC=All users have left the voice channel. The player has been paused.
 eventAutoResumed=User presence detected, automatically resuming the player.
+eventAutoStop=All user have left the voice channel. The player has been cleared.
 commandsFun=Fun
 commandsMemes=Memes
 commandsUtility=Utility


### PR DESCRIPTION
Allows to configure the player to clear all songs if everyone leaves instead of just pausing it.

Depends on FredBoat/Backend#17