### PR TITLE
Add hastebin fallback for selfhosters that do not have a wastebin account

### DIFF
--- a/config/templates/fredboat.yml
+++ b/config/templates/fredboat.yml
@@ -126,6 +126,10 @@ credentials:
   imgurClientId:  ""
 
 
+  # Used by ;;export command. Only set this if you have a https://wastebin.party account.
+  wastebinUser:     ""
+  wastebinPass:     ""
+
   # Used to retrieve Spotify playlists
   # Get them from here: https://developer.spotify.com/my-applications
   spotifyId:      ""


### PR DESCRIPTION
Add Hastebin as a fallback, assuming most selfhosters will not have a wastebin account.
This also fixes guilddebug, since it uses the same method.